### PR TITLE
Resize string buffer to account for bytes instead of chars

### DIFF
--- a/Assets/FishNet/Runtime/Serializing/Writer.cs
+++ b/Assets/FishNet/Runtime/Serializing/Writer.cs
@@ -423,9 +423,10 @@ namespace FishNet.Serializing
              * never intentionally inflict allocations on itself. 
              * Reader ensures string count cannot exceed received
              * packet size. */
-            if (value.Length >= _stringBuffer.Length)
+            int valueMaxBytes = _encoding.GetMaxByteCount(value.Length);
+            if (valueMaxBytes >= _stringBuffer.Length)
             {
-                int nextSize = (_stringBuffer.Length * 2) + value.Length;
+                int nextSize = (_stringBuffer.Length * 2) + valueMaxBytes;
                 Array.Resize(ref _stringBuffer, nextSize);
             }
 


### PR DESCRIPTION
String buffer had some trouble fitting non-ascii characters.

Using `GetMaxByteCount()` instead of `GetByteCount()` to avoid double processing at the cost of memories (especially when sending only ascii ranged characters).