### PR TITLE
Fixed Infinite Recursion in NetworkTransform

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
@@ -910,8 +910,10 @@ namespace FishNet.Component.Transforming
         /// Moves to a GoalData. Automatically determins if to use data from server or client.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void MoveToTarget(float deltaOverride = -1f)
+        private void MoveToTarget(float deltaOverride = -1f, uint i = 0)
         {
+            if (i > 512)
+                return;
             if (!_queueReady)
                 return;
             //Cannot move if neither is active.
@@ -998,7 +1000,7 @@ namespace FishNet.Component.Transforming
                     _goalDataCache.Push(_currentGoalData);
                     SetCurrentGoalData(_goalDataQueue.Dequeue());
                     if (leftOver > 0f)
-                        MoveToTarget(leftOver);
+                        MoveToTarget(leftOver, i+1);
                 }
                 //No more in buffer, see if can extrapolate.
                 else
@@ -1032,7 +1034,7 @@ namespace FishNet.Component.Transforming
             //If relaying from client.
             if (clientAuthoritativeWithOwner)
             {
-                if (_receivedClientData.HasData)
+                if (_receivedClientData.HasData && _receivedClientData.Writer is not null)
                 {
                     _changedSinceStart = true;
                     //Resend data from clients.


### PR DESCRIPTION
NetworkTransform's MoveToTarget would sometimes recurse until it ran out of stack space. Since what it is working on is in a queue I don't think limiting the recursion will break anything (and testing in our project didn't seam to show any regressions).

Additionally on line 1035/1037 we added a check that wouldn't resend data if the writter was not set. We found that this would also rarely occur. Like above adding this check and just letting the change occur a moment later doesn't seam to cause any regressions (that last for more than a frame).