### PR TITLE
fix: set the scene handles passed to SceneUnloadEndEventArgs()

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -497,7 +497,7 @@ namespace FishNet.Managing.Scened
         /// <param name="sqd"></param>
         private void InvokeOnSceneUnloadEnd(UnloadQueueData sqd, List<Scene> unloadedScenes)
         {
-            int[] handles = new int[unloadedScenes.Count];
+            var handles = unloadedScenes.Select(s => s.handle).ToArray();
             OnUnloadEnd?.Invoke(new SceneUnloadEndEventArgs(sqd, handles));
         }
         /// <summary>


### PR DESCRIPTION
SceneManager.InvokeOnSceneUnloadEnd didnot set the handles.

Original code:
```
        private void InvokeOnSceneUnloadEnd(UnloadQueueData sqd, List<Scene> unloadedScenes)
        {
            int[] handles = new int[unloadedScenes.Count];
            OnUnloadEnd?.Invoke(new SceneUnloadEndEventArgs(sqd, handles));
        }
```
new code:
```
        private void InvokeOnSceneUnloadEnd(UnloadQueueData sqd, List<Scene> unloadedScenes)
        {
            var handles = unloadedScenes.Select(s => s.handle).ToArray();
            OnUnloadEnd?.Invoke(new SceneUnloadEndEventArgs(sqd, handles));
        }
```

Before there was no way in the SceneManager.OnUnloadEnd delegate event to distinguish which scene has been unloaded since the handles are all zero