### PR TITLE
Fixed not matching char case in OnSrvConnectionState

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Server/ServerManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Server/ServerManager.cs
@@ -371,7 +371,7 @@ namespace FishNet.Managing.Server
             {
                 Transport t = NetworkManager.TransportManager.GetTransport(args.TransportIndex);
                 string tName = (t == null) ? "Unknown" : t.GetType().Name;
-                Debug.Log($"Local Server is {state.ToString().ToLower()} for {tName}.");
+                Debug.Log($"Local server is {state.ToString().ToLower()} for {tName}.");
             }
 
             NetworkManager.UpdateFramerate();


### PR DESCRIPTION
Client equivalent of this log displays `client` lowercase. Server version was logging uppercase, so I fixed it.