### PR TITLE
RigidbodyPauser now doesn't cause constant resetting of animators

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
@@ -31,6 +31,10 @@ namespace FishNet.Component.Prediction
             /// Scene of this rigidbody when being set kinematic.
             /// </summary>
             public Scene SimulatedScene;
+            /// <summary>
+            /// Cached parent of the 
+            /// </summary>
+            public Transform Parent;
 
             public RigidbodyData(Rigidbody rb)
             {
@@ -39,6 +43,7 @@ namespace FishNet.Component.Prediction
                 Velocity = Vector3.zero;
                 AngularVelocity = Vector3.zero;
                 SimulatedScene = rb.gameObject.scene;
+                Parent = rb.transform.parent;
             }
 
             public void Update(Rigidbody rb)
@@ -69,6 +74,10 @@ namespace FishNet.Component.Prediction
             /// Scene of this rigidbody when being set kinematic.
             /// </summary>
             public Scene SimulatedScene;
+            /// <summary>
+            /// Cached parent of the 
+            /// </summary>
+            public Transform Parent;
 
             public Rigidbody2DData(Rigidbody2D rb)
             {
@@ -77,6 +86,7 @@ namespace FishNet.Component.Prediction
                 Velocity = Vector2.zero;
                 AngularVelocity = 0f;
                 SimulatedScene = rb.gameObject.scene;
+                Parent = rb.transform.parent;
             }
 
             public void Update(Rigidbody2D rb)
@@ -210,6 +220,7 @@ namespace FishNet.Component.Prediction
                     rb.velocity = rbData.Velocity;
                     rb.angularVelocity = rbData.AngularVelocity;
                     SceneManager.MoveGameObjectToScene(rb.transform.root.gameObject, rbData.SimulatedScene);
+                    rb.transform.SetParent(rbData.Parent);
                     return true;
                 }
             }
@@ -236,6 +247,7 @@ namespace FishNet.Component.Prediction
                     rb.velocity = rbData.Velocity;
                     rb.angularVelocity = rbData.AngularVelocity;
                     SceneManager.MoveGameObjectToScene(rb.transform.root.gameObject, rbData.SimulatedScene);
+                    rb.transform.SetParent(rbData.Parent);
                     return true;
                 }
             }
@@ -275,7 +287,9 @@ namespace FishNet.Component.Prediction
 
                     rbData.Update(rb);
                     _rigidbodyDatas[index] = rbData;
-                    SceneManager.MoveGameObjectToScene(rb.transform.root.gameObject, kinematicScene);
+
+                    rb.transform.SetParent(null);
+                    SceneManager.MoveGameObjectToScene(rb.gameObject, kinematicScene);
                     return true;
                 }
             }
@@ -301,7 +315,8 @@ namespace FishNet.Component.Prediction
 
                     rbData.Update(rb);
                     _rigidbody2dDatas[index] = rbData;
-                    SceneManager.MoveGameObjectToScene(rb.transform.root.gameObject, kinematicScene);
+                    rb.transform.SetParent(null);
+                    SceneManager.MoveGameObjectToScene(rb.gameObject, kinematicScene);
                     return true;
                 }
             }

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
@@ -221,7 +221,7 @@ namespace FishNet.Component.Prediction
 
                     rb.velocity = rbData.Velocity;
                     rb.angularVelocity = rbData.AngularVelocity;
-                    SceneManager.MoveGameObjectToScene(rb.transform.root.gameObject, rbData.SimulatedScene);
+                    SceneManager.MoveGameObjectToScene(rb.gameObject, rbData.SimulatedScene);
                     rb.transform.SetParent(rbData.Parent);
                     return true;
                 }
@@ -248,7 +248,7 @@ namespace FishNet.Component.Prediction
 
                     rb.velocity = rbData.Velocity;
                     rb.angularVelocity = rbData.AngularVelocity;
-                    SceneManager.MoveGameObjectToScene(rb.transform.root.gameObject, rbData.SimulatedScene);
+                    SceneManager.MoveGameObjectToScene(rb.gameObject, rbData.SimulatedScene);
                     rb.transform.SetParent(rbData.Parent);
                     return true;
                 }

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
@@ -51,6 +51,7 @@ namespace FishNet.Component.Prediction
                 Velocity = rb.velocity;
                 AngularVelocity = rb.angularVelocity;
                 SimulatedScene = rb.gameObject.scene;
+                Parent = rb.transform.parent;
             }
         }
         /// <summary>
@@ -94,6 +95,7 @@ namespace FishNet.Component.Prediction
                 Velocity = rb.velocity;
                 AngularVelocity = rb.angularVelocity;
                 SimulatedScene = rb.gameObject.scene;
+                Parent = rb.transform.parent;
             }
         }
         #endregion

--- a/Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs
@@ -622,6 +622,8 @@ namespace FishNet.Managing.Timing
         /// <param name="enabled"></param>
         public void SetPhysicsMode(PhysicsMode mode)
         {
+            _physicsMode = mode;
+            
             //Disable.
             if (mode == PhysicsMode.Disabled || mode == PhysicsMode.TimeManager)
             {


### PR DESCRIPTION
This resolves an issue where Animators in parents of a PredictedObject would be constantly reset (as they reset their properties when moving scenes) when pausing/unpausing via RigidbodyPauser (see discord thread: https://discord.com/channels/424284635074134018/1046714101478469662)

Now RigidbodyPauser does the following:

1. Caches original parent upon creation and in the Update method of `RigidbodyData`/`Rigidbody2DData`
2. Unparents the Rigidbody (making it a root object in the scene) when pausing and moving scenes 
3. Reparents the Rigidbody to the cached parents when unpausing