### PR TITLE
Fix getting started window trying to show without a graphics device

### DIFF
--- a/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
+++ b/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
@@ -193,7 +193,7 @@ namespace FishNet.Editing
             EditorApplication.update -= ShowGettingStarted;
 
             string showedSplash = "ShowedFishNetGettingStarted";
-            bool shown = EditorPrefs.GetBool(showedSplash, false);
+            bool shown = EditorPrefs.GetBool(showedSplash, false) || Application.isBatchMode;
 
             if (!shown)
             {


### PR DESCRIPTION
While using Unity in command line, startup window may cause unneccesary error, this can be easily avoided by checking Application.isBatchMode, how to test? - run "Unity.exe -nographics -batchmode -projectPath <path> [whatever other flags you might want to add]" I did not test if it does work but I strongly believe that it does because its just one line of code and the error is pretty edge case anyway so anyway it won't hurt