### PR TITLE
Allow scene loads to use name and path

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/SceneLoadData.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/SceneLoadData.cs
@@ -82,8 +82,9 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="sceneNames">Scenes to load by name.</param>
-        public SceneLoadData(string[] sceneNames) : this(sceneNames, null) { }
+        /// <param name="scenes">Scenes to load.</param>
+        /// <param name="paths">True if scenes contains paths to scenes. False if scenes contains scene names.</param>
+        public SceneLoadData(string[] scenes, bool paths = false) : this(scenes, null, paths) { }
         /// <summary>
         /// 
         /// </summary>
@@ -118,11 +119,12 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="sceneNames">Scenes to load by Name.</param>
+        /// <param name="scenes">Scenes to load.</param>
+        /// <param name="paths">True if scenes contains paths to scenes. False if scenes contains scene names.</param>
         /// <param name="movedNetworkObjects">NetworkObjects to move to the first specified scene.</param>
-        public SceneLoadData(string[] sceneNames, NetworkObject[] movedNetworkObjects)
+        public SceneLoadData(string[] scenes, NetworkObject[] movedNetworkObjects, bool paths = false)
         {
-            SceneLookupData[] datas = SceneLookupData.CreateData(sceneNames);
+            SceneLookupData[] datas = SceneLookupData.CreateData(scenes, paths);
             Construct(datas, movedNetworkObjects);
         }
         /// <summary>

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -688,7 +688,7 @@ namespace FishNet.Managing.Scened
             else if (asServer && data.ScopeType == SceneScopeType.Global)
             {
                 _globalSceneLoadData = data.SceneLoadData;
-                string[] names = data.SceneLoadData.SceneLookupDatas.GetNames();
+                string[] names = data.SceneLoadData.SceneLookupDatas.GetReferences();
                 //If replacing.
                 if (replaceScenes != ReplaceOption.None)
                 {
@@ -915,7 +915,7 @@ namespace FishNet.Managing.Scened
                 * 1f / 2f is 0.5f. */
                 float maximumIndexWorth = (1f / (float)loadableScenes.Count);
 
-                _sceneProcessor.BeginLoadAsync(loadableScenes[i].Name, loadSceneParameters);
+                _sceneProcessor.BeginLoadAsync(loadableScenes[i].Reference, loadSceneParameters);
                 while (!_sceneProcessor.IsPercentComplete())
                 {
                     float percent = _sceneProcessor.GetPercentComplete();
@@ -979,8 +979,10 @@ namespace FishNet.Managing.Scened
 
                         /* Shouldn't be possible since the scene will always exist either by 
                          * just being loaded or already loaded. */
-                        if (string.IsNullOrEmpty(lastSameSceneName.name))
-                            _networkManager.LogError($"Scene {data.SceneLoadData.SceneLookupDatas[0].Name} could not be found in loaded scenes.");
+                        if (data.SceneLoadData.SceneLookupDatas[0].IsPath && string.IsNullOrEmpty(lastSameSceneName.path))
+                            _networkManager.LogError($"Scene {data.SceneLoadData.SceneLookupDatas[0].Reference} could not be found in loaded scenes.");
+                        else if (!data.SceneLoadData.SceneLookupDatas[0].IsPath && string.IsNullOrEmpty(lastSameSceneName.name))
+                            _networkManager.LogError($"Scene {data.SceneLoadData.SceneLookupDatas[0].Reference} could not be found in loaded scenes.");
                         else
                             firstValidScene = lastSameSceneName;
                     }
@@ -1808,7 +1810,7 @@ namespace FishNet.Managing.Scened
             int startCount = newGlobalScenes.Count;
             //Remove scenes.
             for (int i = 0; i < datas.Length; i++)
-                newGlobalScenes.Remove(datas[i].Name);
+                newGlobalScenes.Remove(datas[i].Reference);
 
             //If any were removed remake globalscenes.
             if (startCount != newGlobalScenes.Count)


### PR DESCRIPTION
Feature implementation for #188.

FishNet currently disregards the full path to a scene when loading. This can cause the incorrect scene to load if the scenes have been given the same name.

This change allows you to load scenes by path rather than name if preferred.
E.g. Assuming a dir structure of:
- `Assets/Game1/Game.unity`
- `Assets/Game2/Game.unity`

```
// Causes a load of Assets/Game1/Game.unity
SceneLoadData sld = new SceneLoadData(new []string {"Assets/Game1/Game.unity"}, false);
// Causes a load of Assets/Game1/Game.unity
SceneLoadData sld = new SceneLoadData(new []string {"Assets/Game2/Game.unity"}, false);

// Causes a load of Assets/Game1/Game.unity
SceneLoadData sld = new SceneLoadData(new []string {"Assets/Game1/Game.unity"}, true);
// Causes a load of Assets/Game2/Game.unity
SceneLoadData sld = new SceneLoadData(new []string {"Assets/Game2/Game.unity"}, true);
```

All new `isPath` arguments have been defaulted to false, so the historic behaviour will remain unless the end-user specifically enables this somewhere.

I have not updated any examples etc here because Rider couldn't load the additional solutions required.

I have made these changes in my local project and it's working, but the additive scenes have had very limited testing. I would recommend reviewing my logic to make sure it's good, since my exposure to scene loading in FN and Unity has been somewhat limited.