### PR TITLE
Automatically Activate Option for SceneManager With New OnAwaitingActivation Event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ Documentation
 *.csproj
 *.vs/
 *.vsconfig
+Assets/FishNet/Runtime/FishNet.Runtime.csproj.meta
+Assets/FishNet/Runtime/UpgradeLog.htm
+Assets/FishNet/Runtime/UpgradeLog2.htm
+Assets/FishNet/Runtime/obj/Debug/.NETFramework,Version=v4.0.AssemblyAttributes.cs
+Assets/FishNet/Runtime/obj/Debug/DesignTimeResolveAssemblyReferencesInput.cache
+Assets/FishNet/Runtime/obj/Debug/FishNet.Runtime.csproj.AssemblyReference.cache

--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,3 @@ Documentation
 *.csproj
 *.vs/
 *.vsconfig
-Assets/FishNet/Runtime/FishNet.Runtime.csproj.meta
-Assets/FishNet/Runtime/UpgradeLog.htm
-Assets/FishNet/Runtime/UpgradeLog2.htm
-Assets/FishNet/Runtime/obj/Debug/.NETFramework,Version=v4.0.AssemblyAttributes.cs
-Assets/FishNet/Runtime/obj/Debug/DesignTimeResolveAssemblyReferencesInput.cache
-Assets/FishNet/Runtime/obj/Debug/FishNet.Runtime.csproj.AssemblyReference.cache

--- a/Assets/FishNet/Runtime/Generated/ReaderAndWriters/ScenedReaderWriters.cs
+++ b/Assets/FishNet/Runtime/Generated/ReaderAndWriters/ScenedReaderWriters.cs
@@ -142,6 +142,7 @@ namespace FishNet.Runtime
                 writer.WriteBoolean(true);
             else
                 writer.WriteBoolean(false);
+            writer.WriteBoolean(value.AutomaticallyActivate);
         }
 
         public static void Write___Systemu002EStringu005Bu005D(this Writer writer, string[] value)
@@ -247,7 +248,14 @@ namespace FishNet.Runtime
         public static LoadOptions Read___FishNetu002EManagingu002EScenedu002EDatau002ELoadOptions(
           this Reader reader)
         {
-            return reader.ReadBoolean() ? (LoadOptions)null : new LoadOptions();
+            if (reader.ReadBoolean())
+            {
+                return (LoadOptions)null;
+            }
+            return new LoadOptions()
+            {
+                AutomaticallyActivate = reader.ReadBoolean()
+            };
         }
 
         public static string[] Read___Systemu002EStringu005Bu005D(this Reader reader)

--- a/Assets/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
@@ -117,6 +117,14 @@ namespace FishNet.Managing.Scened
         }
 
         /// <summary>
+        /// Returns list of loading Async Operations.
+        /// </summary>
+        public override List<AsyncOperation> GetLoadingAsyncOperations()
+        {
+            return _loadingAsyncOperations;
+        }
+
+        /// <summary>
         /// Activates scenes which were loaded.
         /// </summary>
         public override void ActivateLoadedScenes()

--- a/Assets/FishNet/Runtime/Managing/Scened/Events/LoadSceneEventArgs.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/Events/LoadSceneEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace FishNet.Managing.Scened
@@ -72,6 +73,26 @@ namespace FishNet.Managing.Scened
             UnloadedSceneNames = unloadedSceneNames;
         }
 
+
+    }
+
+    public struct SceneAwaitingActivationEventArgs
+    {
+        /// <summary>
+        /// Queue data used by the current scene action.
+        /// </summary>
+        public readonly LoadQueueData QueueData;
+
+        /// <summary>
+        /// List of scene AsyncOperation awaiting activation.
+        /// </summary>
+        public readonly List<AsyncOperation> AwaitingActivation;
+
+        public SceneAwaitingActivationEventArgs(LoadQueueData queueData, List<AsyncOperation> awaitingActivation)
+        {
+            QueueData = queueData;
+            AwaitingActivation = awaitingActivation;
+        }
 
     }
 

--- a/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/LoadOptions.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/LoadOptions.cs
@@ -13,8 +13,16 @@ namespace FishNet.Managing.Scened
         [System.NonSerialized]
         public bool AutomaticallyUnload = true;
         /// <summary>
+        /// Automatically Activate by default will be set to true, this means that when loading scenes at the end of the load the scene will Activate.
+        /// To get control of when a scene activates, set this to false. You will then have to subscribe to OnAwaitingActivation in the SceneManager,
+        /// and set the AsyncOperation.allowSceneActivation to true for the scene to finish the load and activate.
+        /// </summary>
+        [System.NonSerialized]
+        public bool AutomaticallyActivate = true;
+        /// <summary>
         /// False if to only load scenes which are not yet loaded. When true a scene may load multiple times; this is known as scene stacking. Only the server is able to stack scenes; clients will load a single instance. Global scenes cannot be stacked.
         /// </summary>
+        /// 
         [System.NonSerialized]
         public bool AllowStacking;
         /// <summary>
@@ -23,6 +31,7 @@ namespace FishNet.Managing.Scened
         /// </summary>
         [System.NonSerialized]
         public LocalPhysicsMode LocalPhysics = LocalPhysicsMode.None;
+        
         /// <summary>
         /// True to reload a scene if it's already loaded.
         /// This does not function yet.

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneProcessorBase.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneProcessorBase.cs
@@ -78,6 +78,10 @@ namespace FishNet.Managing.Scened
         /// </summary>
         public abstract List<Scene> GetLoadedScenes();
         /// <summary>
+        /// Returns list of loading Async Operations.
+        /// </summary>
+        public abstract List<AsyncOperation> GetLoadingAsyncOperations();
+        /// <summary>
         /// Activates scenes which were loaded.
         /// </summary>
         public abstract void ActivateLoadedScenes();


### PR DESCRIPTION
Added feature that allows the ability to toggle automatically activating scenes on scene load.

Provides users a new Scene Event that they can subscribe to that allows them to control what happens to the scenes they requested to load before activation. If Option is Enabled in SceneLoadData.

If you turn off AutoActivation, then you must subscribe to OnAwaitingActivation and Activate the Scenes after you do whatever logic you want before Activation.

The AwaitingActivationEventArgs will provide the list of Scenes Awaiting Activation.