### PR TITLE
fix using for visual studio codecleanup

### DIFF
--- a/Assets/FishNet/Runtime/Connection/NetworkConnection.PingPong.cs
+++ b/Assets/FishNet/Runtime/Connection/NetworkConnection.PingPong.cs
@@ -1,7 +1,9 @@
 ﻿using FishNet.Managing;
 using FishNet.Managing.Timing;
 using System;
+#pragma warning disable IDE0005
 using UnityEngine;
+#pragma warning restore IDE0005
 
 namespace FishNet.Connection
 {

--- a/Assets/FishNet/Runtime/Connection/NetworkConnection.PingPong.cs
+++ b/Assets/FishNet/Runtime/Connection/NetworkConnection.PingPong.cs
@@ -1,9 +1,6 @@
 ﻿using FishNet.Managing;
 using FishNet.Managing.Timing;
 using System;
-#pragma warning disable IDE0005
-using UnityEngine;
-#pragma warning restore IDE0005
 
 namespace FishNet.Connection
 {
@@ -94,7 +91,7 @@ namespace FishNet.Connection
             //Ping isnt too fast.
             else
             {
-                _excessivePingCount = Mathf.Max(0f, _excessivePingCount - 0.5f);
+                _excessivePingCount = UnityEngine.Mathf.Max(0f, _excessivePingCount - 0.5f);
                 return true;
             }
 #endif


### PR DESCRIPTION
When Code Cleanup is ran on this file this using gets deleted. But it is needed for Mathf.