### PR TITLE
Enqueue correct RpcLink ids instead of the hash

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Server/ServerManager.RpcLinks.cs
+++ b/Assets/FishNet/Runtime/Managing/Server/ServerManager.RpcLinks.cs
@@ -70,8 +70,8 @@ namespace FishNet.Managing.Server
         /// </summary>
         internal void ReturnRpcLinks(Dictionary<uint, RpcLinkType> links)
         {
-            foreach (ushort linkId in links.Keys)
-                _availableRpcLinkIndexes.Enqueue(linkId);
+            foreach (ushort hash in links.Keys)
+                _availableRpcLinkIndexes.Enqueue(links[hash].LinkIndex);
         }
     }
 

--- a/Assets/FishNet/Runtime/Managing/Server/ServerManager.RpcLinks.cs
+++ b/Assets/FishNet/Runtime/Managing/Server/ServerManager.RpcLinks.cs
@@ -70,8 +70,8 @@ namespace FishNet.Managing.Server
         /// </summary>
         internal void ReturnRpcLinks(Dictionary<uint, RpcLinkType> links)
         {
-            foreach (ushort hash in links.Keys)
-                _availableRpcLinkIndexes.Enqueue(links[hash].LinkIndex);
+            foreach (RpcLinkType link in links.Values)
+                _availableRpcLinkIndexes.Enqueue(link.LinkIndex);
         }
     }
 


### PR DESCRIPTION
I was running into a crash when I've used up all 65k initial RPCLink ids. The hashes are in the range 0-7 for me. Since they were enqueued as a new usable id it caused an error, as those ids have different packet-id meanings.