### PR TITLE
[Do not merge] Allow editor testing with [client] [server] attributes

### DIFF
--- a/Assets/FishNet/CodeGenerating/Processing/QOLAttributeProcessor.cs
+++ b/Assets/FishNet/CodeGenerating/Processing/QOLAttributeProcessor.cs
@@ -133,11 +133,13 @@ namespace FishNet.CodeGenerating.Processing
                         return;
                     }
                     //If (!base.IsOwner);
+#if !UNITY_EDITOR
                     if (requireOwnership)
                         base.GetClass<NetworkBehaviourHelper>().CreateLocalClientIsOwnerCheck(methodDef, logging, true, false, true);
                     //Otherwise normal IsClient check.
                     else
                         base.GetClass<NetworkBehaviourHelper>().CreateIsClientCheck(methodDef, logging, useStatic, true);
+#endif
                 }
             }
             else if (qolType == QolAttributeType.Server)
@@ -145,7 +147,9 @@ namespace FishNet.CodeGenerating.Processing
                 if (!StripMethod(methodDef))
                 {
                     LoggingType logging = qolAttribute.GetField("Logging", LoggingType.Warning);
+#if !UNITY_EDITOR
                     base.GetClass<NetworkBehaviourHelper>().CreateIsServerCheck(methodDef, logging, useStatic, true);
+#endif
                 }
             }
 

--- a/Assets/FishNet/Editor.meta
+++ b/Assets/FishNet/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ceef2cf216b56f64fa9c150302f2af28
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Editor/AttributeTest.cs
+++ b/Assets/FishNet/Editor/AttributeTest.cs
@@ -1,0 +1,24 @@
+using FishNet.Object;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AttributeTest 
+{
+
+    private Item _item;
+    [SetUp]
+    public void SetUp()
+    {
+        GameObject go = new GameObject();
+        _item = go.AddComponent<Item>();
+    }
+
+    [Test]
+    public void CanUpdateWeight()
+    {
+        _item.UpdateWeight(0.5f);
+        Assert.AreEqual(_item.Weight, 0.5f);
+    }
+}

--- a/Assets/FishNet/Editor/AttributeTest.cs.meta
+++ b/Assets/FishNet/Editor/AttributeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7520d5e33a03b7f48a54384fff3ffb6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Example/Scripts/Item.cs
+++ b/Assets/FishNet/Example/Scripts/Item.cs
@@ -1,0 +1,14 @@
+using FishNet.Object;
+
+public class Item : NetworkBehaviour
+{
+    private float _weight;
+
+    public float Weight => _weight;
+
+    [Server]
+    public void UpdateWeight(float weight)
+    {
+        _weight = weight;
+    }
+}

--- a/Assets/FishNet/Example/Scripts/Item.cs.meta
+++ b/Assets/FishNet/Example/Scripts/Item.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 561786f17f78d7745a0f6a80bff5456c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I've been confronted to the issue of not being able to write editor test for methods with a client or server attribute. 
Issue is, that the fishnet attributes (client, server) return a null reference exception when doing editor tests in Unity, because of the cached Nob being null.
This PR suggest a simple solution to make methods marked with [server] and [client] attribute testable in editor mode, using conditional compilation.
Two checks are done in QOLAttributeProcessor, to avoid net code being generated in editor mode.