### PR TITLE
Add null checks in ManagedObjects.cs and NetworkObserver.cs

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Object/ManagedObjects.cs
+++ b/Assets/FishNet/Runtime/Managing/Object/ManagedObjects.cs
@@ -261,7 +261,10 @@ namespace FishNet.Managing.Object
         internal virtual void DespawnWithoutSynchronization(bool asServer)
         {
             foreach (NetworkObject nob in Spawned.Values)
-                DespawnWithoutSynchronization(nob, asServer, nob.GetDefaultDespawnType(), false);
+            {
+                var defaultDespawnType = nob ? nob.GetDefaultDespawnType() : default;
+                DespawnWithoutSynchronization(nob, asServer, defaultDespawnType, false);
+            }
 
             Spawned.Clear();
         }

--- a/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -140,7 +140,7 @@ namespace FishNet.Observing
 
         internal void Deinitialize()
         {
-            if (_networkObject != null && _networkObject.IsDeinitializing)
+            if (_networkObject != null && _networkObject.IsDeinitializing && _networkObject.ServerManager)
             {
                 _networkObject.ServerManager.OnRemoteConnectionState -= ServerManager_OnRemoteConnectionState;
                 UnregisterTimedConditions();


### PR DESCRIPTION
Totally up to you if you want to merge this or decline this...

When leaving a game, I'd get exceptions errors that either nob is null or _networkObject.ServerManager is null. So adding these on my side... but figured it could help you too! 🙂

_Using FishNet 3.4.3 Pro with FishyUnityTransport_