### PR TITLE
Bug fix for SceneManager.cs

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -582,14 +582,11 @@ namespace FishNet.Managing.Scened
         /// <returns></returns>
         private string[] GlobalScenesExcludingLoading()
         {
-            HashSet<string> excludedScenes = null;
+            HashSet<string> excludedScenes = new HashSet<string>();
             foreach (string gs in _globalScenes)
             {
                 if (_serverGlobalScenesLoading.Contains(gs))
                 {
-                    if (excludedScenes == null)
-                        excludedScenes = new HashSet<string>();
-
                     excludedScenes.Add(gs);
                 }
             }


### PR DESCRIPTION
I just started learning FishNet for the first time with the 3.6.4 release and this code caused a bug resulting in a NullReferenceException error. I've made a simple project which simply allows a client to connect to a localhost and when the client joins it cannot switch to the online scene, with the console giving the NullReferenceException error as mentioned before. This change fixes the bug.