### PR TITLE
Adds return values to client manager connection functions

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
@@ -190,34 +190,34 @@ namespace FishNet.Managing.Client
         /// <summary>
         /// Stops the local client connection.
         /// </summary>
-        public void StopConnection()
+        public bool StopConnection()
         {
-            NetworkManager.TransportManager.Transport.StopConnection(false);
+            return NetworkManager.TransportManager.Transport.StopConnection(false);
         }
 
         /// <summary>
         /// Starts the local client connection.
         /// </summary>
-        public void StartConnection()
+        public bool StartConnection()
         {
-            NetworkManager.TransportManager.Transport.StartConnection(false);
+            return NetworkManager.TransportManager.Transport.StartConnection(false);
         }
 
         /// <summary>
         /// Sets the transport address and starts the local client connection.
         /// </summary>
-        public void StartConnection(string address)
+        public bool StartConnection(string address)
         {
-            StartConnection(address, NetworkManager.TransportManager.Transport.GetPort());
+            return StartConnection(address, NetworkManager.TransportManager.Transport.GetPort());
         }
         /// <summary>
         /// Sets the transport address and port, and starts the local client connection.
         /// </summary>
-        public void StartConnection(string address, ushort port)
+        public bool StartConnection(string address, ushort port)
         {
             NetworkManager.TransportManager.Transport.SetClientAddress(address);
             NetworkManager.TransportManager.Transport.SetPort(port);
-            StartConnection();
+            return StartConnection();
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #357 

This pull request modifies the return values of the `ClientManager` connection functions, such as `StartConnection` and `StopConnection`, by changing their return type from `void` to `boolean`. On the other hand, the connection functions of the `ServerManager` already return a `boolean` by default.

By making this change, the return values of the ClientManager connection functions will now indicate whether the connection was successfully established or not, which can be helpful in handling errors or in implementing certain logic.

The underlying functions already return a boolean, which made this change straightforward.