### PR TITLE
Adds virtual OnAwakeNetwork callback to NetworkBehaviour

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkBehaviour.Callbacks.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkBehaviour.Callbacks.cs
@@ -26,6 +26,10 @@ namespace FishNet.Object
 
         #region Private.
         /// <summary>
+        /// True if OnAwakeNetwork has been called.
+        /// </summary>
+        private bool _onAwakeNetworkCalled;
+        /// <summary>
         /// True if OnStartNetwork has been called.
         /// </summary>
         private bool _onStartNetworkCalled;
@@ -57,12 +61,21 @@ namespace FishNet.Object
                 item.OnStopCallback(asServer);
         }
 
+        /// <summary>
+        /// Invokes the <see cref="OnAwakeNetwork"/>.
+        /// </summary>
+        internal void InvokeOnAwakeNetwork()
+        {
+            if (_onAwakeNetworkCalled)
+                return;
+            OnAwakeNetwork();
+        }
 
         /// <summary>
         /// Invokes the OnStart/StopNetwork.
         /// </summary>
         /// <param name="start"></param>
-        internal void InvokeOnNetwork(bool start)
+        internal void InvokeOnStartNetwork(bool start)
         {
             if (start)
             {
@@ -79,7 +92,22 @@ namespace FishNet.Object
         }
 
         /// <summary>
-        /// Called when the network has initialized this object. May be called for server or client but will only be called once.
+        /// Called when the network is deinitializing this object. May be called for server or client but will only be called once.
+        /// This method will run before OnStartNetwork.
+        /// When as host or server this method will run before OnStartServer. 
+        /// When as client only the method will run before OnStartClient.
+        /// </summary>
+#if UNITY_2020_3_OR_NEWER && UNITY_EDITOR_WIN
+        [OverrideMustCallBase(BaseCallMustBeFirstStatement = true)]
+#endif
+        public virtual void OnAwakeNetwork()
+        {
+            _onAwakeNetworkCalled = true;
+        }
+
+        /// <summary>
+        /// Called when the network is deinitializing this object. May be called for server or client but will only be called once.
+        /// This method will run after OnAwakeNetwork.
         /// When as host or server this method will run before OnStartServer. 
         /// When as client only the method will run before OnStartClient.
         /// </summary>
@@ -102,6 +130,7 @@ namespace FishNet.Object
         public virtual void OnStopNetwork()
         {
             _onStopNetworkCalled = true;
+            _onAwakeNetworkCalled = false;
             _onStartNetworkCalled = false;
         }
 

--- a/Assets/FishNet/Runtime/Object/NetworkBehaviour.QOL.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkBehaviour.QOL.cs
@@ -98,6 +98,7 @@ namespace FishNet.Object
         /// </summary>
 #if UNITY_2020_3_OR_NEWER && UNITY_EDITOR_WIN
         [PreventUsageInside("global::FishNet.Object.NetworkBehaviour", "OnStartServer", "")]
+        [PreventUsageInside("global::FishNet.Object.NetworkBehaviour", "OnAwakeNetwork", " Use base.Owner.IsLocalClient instead.")]
         [PreventUsageInside("global::FishNet.Object.NetworkBehaviour", "OnStartNetwork", " Use base.Owner.IsLocalClient instead.")]
         [PreventUsageInside("global::FishNet.Object.NetworkBehaviour", "Awake", "")]
         [PreventUsageInside("global::FishNet.Object.NetworkBehaviour", "Start", "")]

--- a/Assets/FishNet/Runtime/Object/NetworkObject.Callbacks.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkObject.Callbacks.cs
@@ -22,9 +22,13 @@ namespace FishNet.Object
             //Set that client or server is active before callbacks.
             SetActiveStatus(true, asServer);
 
+            //Invoke OnAwakeNetwork.
+            for (int i = 0; i < NetworkBehaviours.Length; i++)
+                NetworkBehaviours[i].InvokeOnAwakeNetwork();
+
             //Invoke OnStartNetwork.
             for (int i = 0; i < NetworkBehaviours.Length; i++)
-                NetworkBehaviours[i].InvokeOnNetwork(true);
+                NetworkBehaviours[i].InvokeOnStartNetwork(true);
 
             //As server.
             if (asServer)
@@ -115,7 +119,7 @@ namespace FishNet.Object
             if (asServer || (!asServer && !IsServer))
             {
                 for (int i = 0; i < NetworkBehaviours.Length; i++)
-                    NetworkBehaviours[i].InvokeOnNetwork(false);
+                    NetworkBehaviours[i].InvokeOnStartNetwork(false);
             }
 
             if (asServer)


### PR DESCRIPTION
I'm currently developing a Stats System asset for a FishNet and want my NetworkBehaviour to initialize before the others. For that I need an analogue of Unity Awake() method. I would be glad if you could accept this PR.

```csharp
public override void OnAwakeNetwork() // Called before OnStartNetwork
{
    base.OnAwakeNetwork();
}

public override void OnStartNetwork()
{
    base.OnStartNetwork();
}
```