### PR TITLE
Add conditional preprocessor directives to prevent ParrelSync warnings

### DIFF
--- a/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
+++ b/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
@@ -7,9 +7,6 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-#if PARRELSYNC
-using ParrelSync;
-#endif
 
 namespace FishNet.Editing
 {
@@ -125,7 +122,7 @@ namespace FishNet.Editing
         public static void RebuildSceneIds()
         {
 #if PARRELSYNC
-            if (ClonesManager.IsClone())
+            if (ParrelSync.ClonesManager.IsClone() && ParrelSync.Preferences.AssetModPref.Value)
             {
                 Debug.Log("Cannot perform this operation on a ParrelSync clone");
                 return;
@@ -166,7 +163,7 @@ namespace FishNet.Editing
         public static void RebuildDefaultPrefabs()
         {
 #if PARRELSYNC
-            if (ClonesManager.IsClone())
+            if (ParrelSync.ClonesManager.IsClone() && ParrelSync.Preferences.AssetModPref.Value)
             {
                 Debug.Log("Cannot perform this operation on a ParrelSync clone");
                 return;
@@ -190,7 +187,7 @@ namespace FishNet.Editing
         public static void RemoveDuplicateNetworkObjects()
         {
 #if PARRELSYNC
-            if (ClonesManager.IsClone())
+            if (ParrelSync.ClonesManager.IsClone() && ParrelSync.Preferences.AssetModPref.Value)
             {
                 Debug.Log("Cannot perform this operation on a ParrelSync clone");
                 return;

--- a/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
+++ b/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
@@ -7,6 +7,9 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+#if PARRELSYNC
+using ParrelSync;
+#endif
 
 namespace FishNet.Editing
 {
@@ -121,6 +124,14 @@ namespace FishNet.Editing
         [MenuItem("Fish-Networking/Rebuild SceneIds", false, 20)]
         public static void RebuildSceneIds()
         {
+#if PARRELSYNC
+            if (ClonesManager.IsClone())
+            {
+                Debug.Log("Cannot perform this operation on a ParrelSync clone");
+                return;
+            }
+#endif
+
             int generatedCount = 0;
             for (int i = 0; i < SceneManager.sceneCount; i++)
             {
@@ -154,6 +165,14 @@ namespace FishNet.Editing
         [MenuItem("Fish-Networking/Refresh Default Prefabs", false, 22)]
         public static void RebuildDefaultPrefabs()
         {
+#if PARRELSYNC
+            if (ClonesManager.IsClone())
+            {
+                Debug.Log("Cannot perform this operation on a ParrelSync clone");
+                return;
+            }
+#endif
+
             Debug.Log("Refreshing default prefabs.");
             Generator.GenerateFull(null, true);
         }
@@ -170,6 +189,14 @@ namespace FishNet.Editing
 
         public static void RemoveDuplicateNetworkObjects()
         {
+#if PARRELSYNC
+            if (ClonesManager.IsClone())
+            {
+                Debug.Log("Cannot perform this operation on a ParrelSync clone");
+                return;
+            }
+#endif
+
             List<NetworkObject> foundNobs = new List<NetworkObject>();
 
             foreach (string path in Generator.GetPrefabFiles("Assets", new HashSet<string>(), true))

--- a/Assets/FishNet/Runtime/Editor/PrefabCollectionGenerator/Generator.cs
+++ b/Assets/FishNet/Runtime/Editor/PrefabCollectionGenerator/Generator.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 using UnityDebug = UnityEngine.Debug;
 using Debug = UnityEngine.Debug;
 #if PARRELSYNC
-using ParrelSync;
+//using ParrelSync;
 #endif
 
 namespace FishNet.Editing.PrefabCollectionGenerator
@@ -210,7 +210,7 @@ namespace FishNet.Editing.PrefabCollectionGenerator
         public static void GenerateChanged(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, PrefabGeneratorConfigurations settings = null)
         {
 #if PARRELSYNC
-            if (ClonesManager.IsClone())
+            if (ParrelSync.ClonesManager.IsClone() && ParrelSync.Preferences.AssetModPref.Value)
             {
                 Debug.Log("Skipping prefab generation in ParrelSync clone");
                 return;
@@ -317,7 +317,7 @@ namespace FishNet.Editing.PrefabCollectionGenerator
         public static void GenerateFull(PrefabGeneratorConfigurations settings = null, bool forced = false)
         {
 #if PARRELSYNC
-            if (ClonesManager.IsClone())
+            if (ParrelSync.ClonesManager.IsClone() && ParrelSync.Preferences.AssetModPref.Value)
             {
                 Debug.Log("Skipping prefab generation in ParrelSync clone");
                 return;
@@ -485,7 +485,7 @@ namespace FishNet.Editing.PrefabCollectionGenerator
             }
 
 #if PARRELSYNC
-            if (!ClonesManager.IsClone())
+            if (!ParrelSync.ClonesManager.IsClone() && ParrelSync.Preferences.AssetModPref.Value)
             {
 #endif
                 if (_cachedDefaultPrefabs == null)

--- a/Assets/FishNet/Runtime/FishNet.Runtime.asmdef
+++ b/Assets/FishNet/Runtime/FishNet.Runtime.asmdef
@@ -1,9 +1,11 @@
 {
     "name": "FishNet.Runtime",
+    "rootNamespace": "",
     "references": [
         "GUID:9e24947de15b9834991c9d8411ea37cf",
         "GUID:84651a3751eca9349aac36a66bba901b",
-        "GUID:69448af7b92c7f342b298e06a37122aa"
+        "GUID:69448af7b92c7f342b298e06a37122aa",
+        "GUID:894a6cc6ed5cd2645bb542978cbed6a9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -12,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.veriorpies.parrelsync",
+            "expression": "1.2",
+            "define": "PARRELSYNC"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/LiteNetLib/LiteNetLib.csproj.meta
+++ b/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/LiteNetLib/LiteNetLib.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2ad85b0f43f25f1499c27a4dca23ddd8
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/FishNet.sln
+++ b/FishNet.sln
@@ -3,15 +3,17 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FishNet.Runtime", "FishNet.Runtime.csproj", "{69D0C159-BAB4-689B-687E-9E213DFB5A44}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{5ED35FB8-7A21-7C15-DB72-386947C92520}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FishNet.Example", "FishNet.Example.csproj", "{FD83BAE0-85A6-4DD6-BE4C-CFCAF9D19E43}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FishNet.Demos", "FishNet.Demos.csproj", "{136A7A12-C446-BC06-2B59-E13B4B55C391}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unity.FishNet.Codegen", "Unity.FishNet.Codegen.csproj", "{486584D8-1B68-74D0-B2EE-6A18C8D7352A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{5ED35FB8-7A21-7C15-DB72-386947C92520}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FishNet.Codegen.Cecil", "FishNet.Codegen.Cecil.csproj", "{D1887853-8ACF-F4A5-08F5-BE1B0604D38E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unity.FishNet.Codegen", "Unity.FishNet.Codegen.csproj", "{486584D8-1B68-74D0-B2EE-6A18C8D7352A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParrelSync", "ParrelSync.csproj", "{CF399CF5-4F47-D59E-FF0B-F51829825C7D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,10 +25,6 @@ Global
 		{69D0C159-BAB4-689B-687E-9E213DFB5A44}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69D0C159-BAB4-689B-687E-9E213DFB5A44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69D0C159-BAB4-689B-687E-9E213DFB5A44}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FD83BAE0-85A6-4DD6-BE4C-CFCAF9D19E43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD83BAE0-85A6-4DD6-BE4C-CFCAF9D19E43}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD83BAE0-85A6-4DD6-BE4C-CFCAF9D19E43}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -35,14 +33,22 @@ Global
 		{136A7A12-C446-BC06-2B59-E13B4B55C391}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{136A7A12-C446-BC06-2B59-E13B4B55C391}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{136A7A12-C446-BC06-2B59-E13B4B55C391}.Release|Any CPU.Build.0 = Release|Any CPU
-		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED35FB8-7A21-7C15-DB72-386947C92520}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D1887853-8ACF-F4A5-08F5-BE1B0604D38E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1887853-8ACF-F4A5-08F5-BE1B0604D38E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1887853-8ACF-F4A5-08F5-BE1B0604D38E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1887853-8ACF-F4A5-08F5-BE1B0604D38E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{486584D8-1B68-74D0-B2EE-6A18C8D7352A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF399CF5-4F47-D59E-FF0B-F51829825C7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF399CF5-4F47-D59E-FF0B-F51829825C7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF399CF5-4F47-D59E-FF0B-F51829825C7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF399CF5-4F47-D59E-FF0B-F51829825C7D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds:
1. An assembly definition reference to the `projectCloner` assembly (the ParrelSync assembly) in the FishNet.Runtime assembly definition.
2. An entry in the `Version Defines` of the FishNet.Runtime assembly definition to conditionally add the `#PARRELSYNC` preprocessor directive if the `com.veriorpies.parrelsync` package is installed in the same project.
3. Wraps and/or early returns for asset-modification code to prevent ParrelSync warnings