### PR TITLE
feat: dedicated event for client to get currently connected clients to the server

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
@@ -10,6 +10,7 @@ using FishNet.Utility.Extension;
 using FishNet.Utility.Performance;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
@@ -36,6 +37,11 @@ namespace FishNet.Managing.Client
         /// This is only available when using ServerManager.ShareIds.
         /// </summary>
         public event Action<RemoteConnectionStateArgs> OnRemoteConnectionState;
+        /// <summary>
+        /// Called when the server sends all currently connected clients.
+        /// This is only available when using ServerManager.ShareIds.
+        /// </summary>
+        public event Action<ConnectedClientsStateArgs> OnConnectedClientsState;
         /// <summary>
         /// True if the client connection is connected to the server.
         /// </summary>
@@ -144,6 +150,7 @@ namespace FishNet.Managing.Client
 
         /// <summary>
         /// Called when the server sends all currently connected clients.
+        /// This is only available when using ServerManager.ShareIds.
         /// </summary>
         /// <param name="args"></param>
         private void OnConnectedClientsBroadcast(ConnectedClientsBroadcast args)
@@ -153,7 +160,10 @@ namespace FishNet.Managing.Client
             List<int> collection = args.Values;
             //No connected clients except self.
             if (collection == null)
+            {
+                OnConnectedClientsState?.Invoke(new ConnectedClientsStateArgs(Enumerable.Empty<int>()));
                 return;
+            }
 
             int count = collection.Count;
             for (int i = 0; i < count; i++)
@@ -162,7 +172,7 @@ namespace FishNet.Managing.Client
                 Clients[id] = new NetworkConnection(NetworkManager, id, -1, false);
             }
 
-            CollectionCaches<int>.Store(collection);
+            OnConnectedClientsState?.Invoke(new ConnectedClientsStateArgs(collection));
         }
 
         /// <summary>

--- a/Assets/FishNet/Runtime/Transporting/EventStructures.cs
+++ b/Assets/FishNet/Runtime/Transporting/EventStructures.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace FishNet.Transporting
 {
@@ -102,6 +103,22 @@ namespace FishNet.Transporting
             ConnectionState = connectionState;
             ConnectionId = connectionId;
             TransportIndex = transportIndex;
+        }
+    }
+
+    /// <summary>
+    /// Container for connected clients state for a client.
+    /// </summary>
+    public struct ConnectedClientsStateArgs
+    {
+        /// <summary>
+        /// Collection of client ids connected to the server.
+        /// </summary>
+        public IEnumerable<int> ClientIds;
+
+        public ConnectedClientsStateArgs(IEnumerable<int> clientIds)
+        {
+            ClientIds = clientIds;
         }
     }
 


### PR DESCRIPTION
## Purpose of this PR
Introduced a new event for the client to get currently connected clients to the server.

Thus, you can get all the other connected client ids right after a successful connection to the server (right before `ClientManager.OnAuthenticated` event).

## Comments to reviewers
If you want me to provide a usage sample, please, just let me know. Would be happy to help.
