### PR TITLE
Fix Cross-Scene Reference causing a Unity warning in editor

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkObject.ReferenceIds.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkObject.ReferenceIds.cs
@@ -49,15 +49,6 @@ namespace FishNet.Object
         public void SetAssetPathHash(ulong value) => AssetPathHash = value;
         #endregion
 
-#if UNITY_EDITOR
-        /// <summary>
-        /// This is used to store NetworkObjects in the scene during edit time.
-        /// SceneIds are compared against this collection to ensure there are no duplicated.
-        /// </summary>
-        [SerializeField, HideInInspector]
-        private List<NetworkObject> _sceneNetworkObjects = new List<NetworkObject>();
-#endif
-
         /// <summary>
         /// Removes SceneObject state.
         /// This may only be called at runtime.
@@ -188,8 +179,8 @@ namespace FishNet.Object
         private bool IsDuplicateSceneId(ulong id)
         {
             //Find all nobs in scene.
-            _sceneNetworkObjects = GameObject.FindObjectsOfType<NetworkObject>().ToList();
-            foreach (NetworkObject nob in _sceneNetworkObjects)
+            NetworkObject[] sceneNetworkObjects = GameObject.FindObjectsOfType<NetworkObject>();
+            foreach (NetworkObject nob in sceneNetworkObjects)
             {
                 if (nob != null && nob != this && nob.SceneId == id)
                     return true;


### PR DESCRIPTION
Fixes https://github.com/FirstGearGames/FishNet/issues/387

That issue was marked as WontFix, but I think that may have been because I wasn't clear on what the problem was. I hope it's okay to submit a PR to fix it anyway, and hope the fix help to clear up what I meant.

## Background

Unity (indeed not FishNet) logs many warnings about Cross-Scene references when you have multiple scenes open in the editor that have a `NetworkObject` in them.

This is because the `NetworkObject` class has a serialized field that stores all a list of all NetworkObjects in the game, even those across other scenes. This means when the scene tries to save, it tries to save this huge list of references to NetworkObjects, including ones across scenes. Unity doesn't like this and complains.

## Proposed Fix

The the class level list of NetworkObjects that causes the issue is actually private and only used within a single function and recreated every time that function is called, so there's no reason to scope it outside of the function at all.

This PR removes the field and stores it in a function variable instead.

Alternatively, I think keeping the class field without `[SerializedField, HideInInspector]` would also work, but this seemed cleaner since it wasn't referenced anyway.