### PR TITLE
Fix PingDisplay and BandwidthDisplay to work in the unity editor and non-server buiilds

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/Utility/BandwidthDisplay.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Utility/BandwidthDisplay.cs
@@ -56,7 +56,7 @@ namespace FishNet.Component.Utility
         public void SetShowIncoming(bool value) => _showIncoming = value;
         #endregion
 
-#if !UNITY_EDITOR && UNITY_SERVER
+#if UNITY_EDITOR && !UNITY_SERVER
 
         #region Private.
         /// <summary>

--- a/Assets/FishNet/Runtime/Generated/Component/Utility/PingDisplay.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Utility/PingDisplay.cs
@@ -40,7 +40,7 @@ namespace FishNet.Component.Utility
         private bool _hideTickRate = true;
         #endregion
 
-#if !UNITY_EDITOR && UNITY_SERVER
+#if UNITY_EDITOR || !UNITY_SERVER
 
         #region Private.
         /// <summary>


### PR DESCRIPTION
Looks like this [commit](https://github.com/FirstGearGames-Org/FishNet_Supporters/commit/445e63909f0ad51833ef906d0c2159d9967c98a5#r117153880) disabled by mistake the pingdisplay/bandwidth display on the editor and non-server builds, but I think
that we want to contrary here.

