### PR TITLE
Update dead Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Asset Store: https://assetstore.unity.com/packages/tools/network/fish-net-networ
 
 Documentation and Addons: https://fish-networking.gitbook.io/docs/
 
-Discord: [Join Server!](https://discord.gg/Ta9HgDh4Hj)
+Community Discord: https://discord.gg/Ta9HgDh4Hj
 
 
 # Donation Options

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Asset Store: https://assetstore.unity.com/packages/tools/network/fish-net-networ
 
 Documentation and Addons: https://fish-networking.gitbook.io/docs/
 
-Discord: https://discord.gg/fishnetworking
+Discord: [Join Server!](https://discord.gg/Ta9HgDh4Hj)
 
 
 # Donation Options


### PR DESCRIPTION
https://discord.gg/fishnetworking is not a valid Discord invite link. Found and replaced README link with the discord invite from Unity AssetStore page. 