### PR TITLE
Fix for PlayerSpawner component not spawning in specified Spawns

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/Spawning/PlayerSpawner.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Spawning/PlayerSpawner.cs
@@ -98,8 +98,7 @@ namespace FishNet.Component.Spawning
             Quaternion rotation;
             SetSpawn(_playerPrefab.transform, out position, out rotation);
 
-            NetworkObject nob = _networkManager.GetPooledInstantiated(_playerPrefab, true);
-            nob.transform.SetPositionAndRotation(position, rotation);
+            NetworkObject nob = _networkManager.GetPooledInstantiated(_playerPrefab, position, rotation, true);
             _networkManager.ServerManager.Spawn(nob, conn);
 
             //If there are no global scenes 


### PR DESCRIPTION
The line `nob.transform.SetPositionAndRotation(position, rotation);` does not actually affect where the player spawns and also does not move the player into the position and rotation specified by the Spawns array. This PR fixes that by just setting the position and rotation in the `GetPooledInstantiated` call instead.