### PR TITLE
Add event invocations on NetworkBehaviour for after each OnStartXXXX method has been called  

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkBehaviour.Callbacks.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkBehaviour.Callbacks.cs
@@ -4,6 +4,7 @@ using FishNet.CodeAnalysis.Annotations;
 using FishNet.Connection;
 using FishNet.Documenting;
 using FishNet.Object.Synchronizing.Internal;
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
@@ -23,6 +24,21 @@ namespace FishNet.Object
         /// </summary>
         [APIExclude]
         public bool OnStartClientCalled { get; private set; }
+
+        /// <summary>
+        /// This <see cref="Action"/> will be invoked after <see cref="OnStartNetwork"/> is called.
+        /// </summary>
+        public event Action OnStartedOnNetwork;
+
+        /// <summary>
+        /// This <see cref="Action"/> will be invoked after <see cref="OnStartClient"/> is called.
+        /// </summary>
+        public event Action OnStartedOnClient;
+
+        /// <summary>
+        /// This <see cref="Action"/> will be invoked after <see cref="OnStartServer"/> is called.
+        /// </summary>
+        public event Action OnStartedOnServer;
         #endregion
 
         #region Private.
@@ -85,6 +101,7 @@ namespace FishNet.Object
             _onStartNetworkCalled = true;
             _onStopNetworkCalled = false;
             OnStartNetwork();
+            OnStartedOnNetwork?.Invoke();
         }
         /// <summary>
         /// Called when the network has initialized this object. May be called for server or client but will only be called once.
@@ -114,6 +131,7 @@ namespace FishNet.Object
         {
             OnStartServerCalled = true;
             OnStartServer();
+            OnStartedOnServer?.Invoke();
         }
         /// <summary>
         /// Called on the server after initializing this object.
@@ -172,6 +190,7 @@ namespace FishNet.Object
         {
             OnStartClientCalled = true;
             OnStartClient();
+            OnStartedOnClient?.Invoke();
         }
         /// <summary>
         /// Called on the client after initializing this object.


### PR DESCRIPTION
Actions `OnStartedOnNetwork`, `OnStartedOnClient` and `OnStartedOnServer` will be invoked after `OnStartNetwork`, `OnStartClient` and `OnStartServer` have been called respectively.

**Why?**

Because I believe there are currently no syntactically pretty ways to know when an object has been finished spawning/initializing on the network _outside_ the object itself. 

Let's imagine a `Blacksmith` object which spawns an `Item` object for each player upon request, and then gives the item random stats:

```cs
public class Blacksmith : NetworkBehaviour {
    public Item itemObj;

    void OnInteract() {
        RequestItemSpawnServerRpc();
    }

    [ServerRpc(RequireOwnership = false)]
    void RequestItemSpawnServerRpc() {
        GameObject itemClone = Instantiate(itemObj);
        Item itemRef = itemClone.GetComponent<Item>();
                
        Spawn(itemClone);

        // This point is where we would likely encounter the "Cannot complete action because 
        // client is not active. This may also occur if the object is not yet initialized, has 
        // deinitialized, or if it does not contain a NetworkObject component." error, 
        // since we are trying to write on `SyncVar`s before the NetworkObject has been initialized.
        itemRef.attackBoost = UnityEngine.Random.Range(0, 10);
        itemRef.defenseBoost = UnityEngine.Random.Range(0, 10);
    }
}

public class Item : NetworkBehaviour {
        [SyncVar] public float attackBoost;
        [SyncVar] public float defenseBoost;
}
```

So we have to wait until the `Item` has been initialized. It is easy to do this in the `Item` script since we have many helpers such as `NetworkBehaviour.IsSpawned`, `OnStartClient()` etc. But if we need to access this information inside the `Blacksmith` object, the only reliable way seems to be creating a coroutine to wait until the object has been initialized as such:

```cs
    private Item instantiatedItemRef;

    [ServerRpc(RequireOwnership = false)]
    void RequestItemSpawnServerRpc() {
        GameObject itemClone = Instantiate(itemObj);
        instantiatedItemRef = itemClone.GetComponent<Item>();
                
        Spawn(itemClone);

        StartCoroutine(WaitUntilItemSpawn());
    }

    IEnumerator WaitUntilItemSpawn() {
        yield return new WaitUntil(() => instantiatedItemRef.IsSpawned);

        instantiatedItemRef.attackBoost = UnityEngine.Random.Range(0, 10);
        instantiatedItemRef.defenseBoost = UnityEngine.Random.Range(0, 10);
    }
```

While this works, it is a lot of extra code to accomplish what seems to be such a simple task. With this commit, the same goal will be able to be accomplished with much less code:

```cs
    private Item instantiatedItemRef;

    [ServerRpc(RequireOwnership = false)]
    void RequestItemSpawnServerRpc() {
        GameObject itemClone = Instantiate(itemObj);
        instantiatedItemRef = itemClone.GetComponent<Item>();
                
        instantiatedItemRef.OnStartedOnClient += () => {
                instantiatedItemRef.attackBoost = UnityEngine.Random.Range(0, 10);
                instantiatedItemRef.defenseBoost = UnityEngine.Random.Range(0, 10);
        }
        Spawn(itemClone);
    }
```

 