### PR TITLE
App can override client/server targetFrameRate

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
@@ -105,6 +105,14 @@ namespace FishNet.Managing.Client
         /// Maximum frame rate the client may run at. When as host this value runs at whichever is higher between client and server.
         /// </summary>
         internal ushort FrameRate => (_changeFrameRate) ? _frameRate : (ushort)0;
+        /// Sets the maximum frame rate the client may run at. Calling this method will enable ChangeFrameRate.
+        /// </summary>
+        /// <param name="value">New value.</param>
+        public void SetFrameRate(ushort value)
+        {
+            _frameRate = (ushort)Mathf.Clamp(value, 0, NetworkManager.MAXIMUM_FRAMERATE);
+            _changeFrameRate = true;
+        }
         #endregion
 
         #region Private.

--- a/Assets/FishNet/Runtime/Managing/Server/ServerManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Server/ServerManager.cs
@@ -145,6 +145,14 @@ namespace FishNet.Managing.Server
         [Range(1, NetworkManager.MAXIMUM_FRAMERATE)]
         [SerializeField]
         private ushort _frameRate = NetworkManager.MAXIMUM_FRAMERATE;
+        /// Sets the maximum frame rate the server may run at. Calling this method will enable ChangeFrameRate.
+        /// </summary>
+        /// <param name="value">New value.</param>
+        public void SetFrameRate(ushort value)
+        {
+            _frameRate = (ushort)Mathf.Clamp(value, 0, NetworkManager.MAXIMUM_FRAMERATE);
+            _changeFrameRate = true;
+        }
         /// <summary>
         /// True to share the Ids of clients and the objects they own with other clients. No sensitive information is shared.
         /// </summary>


### PR DESCRIPTION
Prior to this change FishNet sets Application.targetFrameRate, and overrides any changes the application makes to its value to, for example, enable the player to lower frame rate to avoid overheating.

This change adds APIs to ClientManager and ServerManager to set a desired frame rate that overrides the values stored in the prefab.