### PR TITLE
Unregister from prediction callbacks in unexpected OnDestroy()

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkObject.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkObject.cs
@@ -405,7 +405,12 @@ namespace FishNet.Object
                 if (NetworkManager.IsServer)
                     NetworkManager.ServerManager.Objects.NetworkObjectUnexpectedlyDestroyed(this, true);
                 if (NetworkManager.IsClient)
+                {
                     NetworkManager.ClientManager.Objects.NetworkObjectUnexpectedlyDestroyed(this, false);
+#if PREDICTION_V2
+                    Prediction_Deinitialize(asServer: false)
+#endif
+                }
             }
 
             /* When destroyed unexpectedly it's


### PR DESCRIPTION
This is a proposed fix for https://github.com/FirstGearGames/FishNet/issues/494

It's not clear to me why we pass "asServer" to deinitialize since it's unused internally but it sounds like only clients need to go through the codepath so I've only added the call there.