### PR TITLE
Add GetTickRatio() api that lives alongside GetTickPercentage()

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs
@@ -770,6 +770,19 @@ namespace FishNet.Managing.Timing
 
         #region Tick conversions.
         /// <summary>
+        /// Returns the 0 to 1 ratio of how far the TimeManager is into the next tick.
+        /// </summary>
+        /// <returns></returns>
+        public double GetTickRatio()
+        {
+            if (_networkManager == null)
+                return default;
+
+            double delta = (_networkManager.IsServer) ? TickDelta : _adjustedTickDelta;
+            double ratio = (_elapsedTickTime / delta);
+            return ratio;
+        }
+        /// <summary>
         /// Returns the percentage of how far the TimeManager is into the next tick.
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
In our code we want to be able to interpolate objects between ticks so we are usually doing interpolations using `GetTickPercent() / 100`. I notice inside `RollbackManager.cs` you're doing the same thing as well as when serializing PreciseTick.

A bigger change could be made to avoid the conversions inside PreciseTick which would then clean up some / 100 stuff in `RollbackManager.cs` but I don't believe I can make a PR for that.