### PR TITLE
Fixed child spawn reference issue results in NullReferenceException

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Server/Object/ServerObjects.cs
+++ b/Assets/FishNet/Runtime/Managing/Server/Object/ServerObjects.cs
@@ -475,7 +475,7 @@ namespace FishNet.Managing.Server
                 base.NetworkManager.LogWarning($"{networkObject.name} is already spawned.");
                 return;
             }
-            if (networkObject.CurrentParentNetworkObject != null && !networkObject.ParentNetworkObject.IsSpawned)
+            if (networkObject.CurrentParentNetworkObject != null && !networkObject.CurrentParentNetworkObject.IsSpawned)
             {
                 base.NetworkManager.LogError($"{networkObject.name} cannot be spawned because it has a parent NetworkObject {networkObject.CurrentParentNetworkObject} which is not spawned.");
                 return;


### PR DESCRIPTION
NullReferenceException when spawning NOB and SetParent called before. 
Reference issue on ParentNetworkObject which was not replaced completly by CurrentParentNetworkObject before.
https://github.com/FirstGearGames/FishNet/commit/aba31ca96548de71d8226ecf32c14615c417b065#diff-72e6ee74bf720ea4debeb12186dd2c1ccfc39adcc410eb8b8cade5fca889e2bdR478
