### PR TITLE
Fix invalid token value for ClientTransportData

### DIFF
--- a/Assets/FishNet/Runtime/Transporting/Transports/Multipass/Multipass.cs
+++ b/Assets/FishNet/Runtime/Transporting/Transports/Multipass/Multipass.cs
@@ -1054,7 +1054,7 @@ namespace FishNet.Transporting.Multipass
         /// <summary>
         /// An unset/invalid ClientTransportData.
         /// </summary>
-        private readonly ClientTransportData INVALID_CLIENTTRANSPORTDATA = new ClientTransportData(0, 0, 0);
+        private static readonly ClientTransportData INVALID_CLIENTTRANSPORTDATA = new ClientTransportData(int.MinValue, int.MinValue, int.MinValue);
         /// <summary>
         /// MultipassId lookup.
         /// </summary>


### PR DESCRIPTION
I believe all zeroes is a valid runtime value for this struct. Choose a different token value, in this case all int.MinValue instead

Fixes https://github.com/FirstGearGames/FishNet/issues/511