### PR TITLE
proposed fix for issue-542

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Client/Object/ClientObjects.cs
+++ b/Assets/FishNet/Runtime/Managing/Client/Object/ClientObjects.cs
@@ -724,9 +724,7 @@ namespace FishNet.Managing.Client
                 }
             }
 
-            // componentIndex is currently unused
-            _ = reader.ReadNetworkBehaviourId(out var nobId);
-            prefabId = (ushort)nobId;
+            prefabId = (ushort)reader.ReadNetworkObjectId();
         }
 
     }

--- a/Assets/FishNet/Runtime/Managing/Client/Object/ClientObjects.cs
+++ b/Assets/FishNet/Runtime/Managing/Client/Object/ClientObjects.cs
@@ -724,7 +724,9 @@ namespace FishNet.Managing.Client
                 }
             }
 
-            prefabId = (ushort)reader.ReadNetworkObjectId();
+            // componentIndex is currently unused
+            _ = reader.ReadNetworkBehaviourId(out var nobId);
+            prefabId = (ushort)nobId;
         }
 
     }

--- a/Assets/FishNet/Runtime/Managing/Object/ManagedObjects.Spawning.cs
+++ b/Assets/FishNet/Runtime/Managing/Object/ManagedObjects.Spawning.cs
@@ -96,7 +96,7 @@ namespace FishNet.Managing.Object
                  * on the other end. This is problematic because the object which is parent
                  * may not be spawned yet. Clients handle caching potentially not yet spawned
                  * objects via Ids. */
-                headerWriter.WriteNetworkBehaviourId(nob.CurrentParentNetworkBehaviour);
+                headerWriter.WriteNetworkObjectId(nob.CurrentParentNetworkBehaviour.ObjectId);
             }
             /* Writing a scene object. */
             if (sceneObject)


### PR DESCRIPTION
fixes https://github.com/FirstGearGames/FishNet/issues/542

- in 4.0.1 the WriteSpawn_Server function in ManagedObjects.Spawning.cs was changed to use WriteNetworkBehaviourId instead of WriteNetworkObjectId. This appends a new byte of data (component index) to the data stream, but the corresponding read was not updated to do the same. This ends up causing parse errors on the client side during spawn events for nested NetworkObjects in certain conditions (specifically, if the nested NetworkObjects' immediate parent is a plain GameObject being used for organizational purposes

This PR reverts to previous behavior, because it looked like there are no current paths that read and validate the componentId written by the new WriteNetworkBehaviourId function. This is probably not the correct long-term fix but it was not clear to me how to handle the reader side for all use-cases, or whether that was even necessary. Switching the read side to use ReadNetworkBehaviourId and disregarding the componentId breaks other uses cases, so this seemed the safest short-term thing to do