### PR TITLE
Fixed NetworkAnimator not always deinitializing properly when an object was unexpectedly destroyed.

### DIFF
--- a/Assets/FishNet/CONTRIBUTORS.txt
+++ b/Assets/FishNet/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
 This file exist only for contributors to submit their name via pull request.
+evbishop

--- a/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs
@@ -427,6 +427,10 @@ namespace FishNet.Component.Animating
         /// Tick when the buffer may begin to run.
         /// </summary>
         private uint _startTick = TimeManagerCls.UNSET_TICK;
+        /// <summary>
+        /// True if subscribed to TimeManager for ticks.
+        /// </summary>
+        private bool _subscribedToTicks;
         #endregion
 
         #region Const.
@@ -457,6 +461,11 @@ namespace FishNet.Component.Animating
             InitializeOnce();
         }
 
+        private void OnDestroy()
+        {
+            ChangeTickSubscription(false);
+        }
+
         [APIExclude]
         public override void OnSpawnServer(NetworkConnection connection)
         {
@@ -469,8 +478,7 @@ namespace FishNet.Component.Animating
 
         public override void OnStartNetwork()
         {
-            base.TimeManager.OnPreTick += TimeManager_OnPreTick;
-            base.TimeManager.OnPostTick += TimeManager_OnPostTick;
+            ChangeTickSubscription(true);
         }
 
         [APIExclude]
@@ -493,10 +501,29 @@ namespace FishNet.Component.Animating
         public override void OnStopNetwork()
         {
             _unsynchronizedLayerStates.Clear();
-            base.TimeManager.OnPreTick -= TimeManager_OnPreTick;
-            base.TimeManager.OnPostTick -= TimeManager_OnPostTick;
+            ChangeTickSubscription(false);
         }
 
+        /// <summary>
+        /// Tries to subscribe to TimeManager ticks.
+        /// </summary>
+        private void ChangeTickSubscription(bool subscribe)
+        {
+            if (subscribe == _subscribedToTicks || base.NetworkManager == null)
+                return;
+
+            _subscribedToTicks = subscribe;
+            if (subscribe)
+            {
+                base.NetworkManager.TimeManager.OnPreTick += TimeManager_OnPreTick;
+                base.NetworkManager.TimeManager.OnPostTick += TimeManager_OnPostTick;
+            }
+            else
+            {
+                base.NetworkManager.TimeManager.OnPreTick -= TimeManager_OnPreTick;
+                base.NetworkManager.TimeManager.OnPostTick -= TimeManager_OnPostTick;
+            }
+        }
 
         /// <summary>
         /// Called right before a tick occurs, as well before data is read.


### PR DESCRIPTION
Basically the same thing that was done to NetworkTransform in 3.11.5.

We've been getting a lot of error reports that include:
```<Exception>: NullReferenceException: Object reference not set to an instance of an object.
FishNet.Component.Animating.NetworkAnimator.TimeManager_OnPreTick () (at <00000000000000000000000000000000>:0)
FishNet.Managing.Timing.TimeManager.IncreaseTick () (at <00000000000000000000000000000000>:0)
FishNet.Managing.Timing.TimeManager.TickUpdate () (at <00000000000000000000000000000000>:0)```

I assume the null ref here refers to TimeManager and hopefully this will fix it.