### PR TITLE
make listening on IPv6 address configurable

### DIFF
--- a/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/Tugboat.cs
+++ b/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/Tugboat.cs
@@ -34,6 +34,12 @@ namespace FishNet.Transporting.Tugboat
         [SerializeField]
         private string _ipv4BindAddress;
         /// <summary>
+        /// Enable IPv6 only on demand to avoid problems in Linux environments where it may have been disabled on host
+        /// </summary>
+        [Tooltip("Enable IPv6, Server listens on IPv4 and IPv6 address")]
+        [SerializeField]
+        private bool _enableIpv6 = true;
+        /// <summary>
         /// IPv6 address to bind server to.
         /// </summary>
         [Tooltip("IPv6 Address to bind server to.")]
@@ -283,7 +289,7 @@ namespace FishNet.Transporting.Tugboat
             if (GetConnectionState(false) != LocalConnectionState.Stopped)
                 base.NetworkManager.LogWarning("PacketLayer is set but will not be applied until the client stops.");
 
-            _server.Initialize(this, _unreliableMTU, _packetLayer);
+            _server.Initialize(this, _unreliableMTU, _packetLayer,_enableIpv6);
             _client.Initialize(this, _unreliableMTU, _packetLayer);
         }
         /// <summary>
@@ -439,7 +445,7 @@ namespace FishNet.Transporting.Tugboat
         /// </summary>
         private bool StartServer()
         {
-            _server.Initialize(this, _unreliableMTU, _packetLayer);
+            _server.Initialize(this, _unreliableMTU, _packetLayer,_enableIpv6);
             UpdateTimeout();
             return _server.StartConnection(_port, _maximumClients, _ipv4BindAddress, _ipv6BindAddress);
         }


### PR DESCRIPTION
On Linux machines in enterprise environments, IPv6 may be disabled and listening on IPv6 addresses lead to an exception in LiteNetLib low level stuff. In consequence IPv4 is not correctly initialized as well. Server side then is not able to send back to client.

With this PR, IPv6 can be disabled by a flag in the Tugboat component.

Same PR for V4 will follow.