### PR TITLE
Fixed preferred active scene on client not being passed through 

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -346,7 +346,8 @@ namespace FishNet.Managing.Scened
                     sld.Params = _globalSceneLoadData.Params;
                     sld.Options = _globalSceneLoadData.Options;
                     sld.ReplaceScenes = _globalSceneLoadData.ReplaceScenes;
-
+                    sld.PreferredActiveScene = _globalSceneLoadData.PreferredActiveScene;
+                    
                     LoadQueueData qd = new LoadQueueData(SceneScopeType.Global, Array.Empty<NetworkConnection>(), sld, _globalScenes, false);
                     //Send message to load the networked scenes.
                     LoadScenesBroadcast msg = new LoadScenesBroadcast()


### PR DESCRIPTION
Fixed preferred active scene on client not being passed through correctly on initial scene load
This was causing a different active scene on server and client in cases where multiple scenes are being used