### PR TITLE
Add null reference check

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkObject.Prediction.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkObject.Prediction.cs
@@ -233,7 +233,7 @@ namespace FishNet.Object
                 }
                 else
                 {
-                    RigidbodyPauser.Pause();
+                    RigidbodyPauser?.Pause();
                 }
 
             }


### PR DESCRIPTION
This commit adds a null reference check to the invocation of `RigidbodyPauser.Pause()`. This is needed because otherwise, for each reconciliation of a non-rigidbody-controlled object, an exception is thrown.