### PR TITLE
Unity math serializers

### DIFF
--- a/Assets/FishNet/Runtime/FishNet.Runtime.asmdef
+++ b/Assets/FishNet/Runtime/FishNet.Runtime.asmdef
@@ -27,12 +27,12 @@
         {
             "name": "com.unity.mathematics",
             "expression": "1.3.1",
-            "define": "UNITYMATHEMATICS131"
+            "define": "UNITYMATHEMATICS_131"
         },
         {
             "name": "com.unity.mathematics",
             "expression": "1.3.2",
-            "define": "UNITYMATHEMATICS132"
+            "define": "UNITYMATHEMATICS_132"
         }
     ],
     "noEngineReferences": false

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4aaaca3090257be40b80f33b9e955446
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/BoolExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/BoolExtensions.cs
@@ -1,0 +1,470 @@
+#if UNITYMATHEMATICS
+
+using Unity.Mathematics;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        public void Writebool2(bool2 value) {
+
+            byte b = 0;
+
+            if (value.x)
+                b |= 1;
+            if (value.y)
+                b |= 2;
+
+            WriteByte(b);
+        }
+
+        public void Writebool3(bool3 value) {
+
+            byte b = 0;
+
+            if (value.x)
+                b |= 1;
+            if (value.y)
+                b |= 2;
+            if (value.z)
+                b |= 4;
+
+            WriteByte(b);
+        }
+
+        public void Writebool4(bool4 value) {
+            byte b = 0;
+
+            if (value.x)
+                b |= 1;
+            if (value.y)
+                b |= 2;
+            if (value.z)
+                b |= 4;
+            if (value.w)
+                b |= 8;
+
+            WriteByte(b);
+        }
+
+        public void Writebool2x2(bool2x2 value) {
+
+            byte b = 0;
+
+            if (value.c0.x)
+                b |= 1;
+            if (value.c0.y)
+                b |= 2;
+            if (value.c1.x)
+                b |= 4;
+            if (value.c1.y)
+                b |= 8;
+
+            WriteByte(b);
+        }
+
+        public void Writebool2x3(bool2x3 value) {
+            byte b = 0;
+
+            if (value.c0.x)
+                b |= 1;
+            if (value.c0.y)
+                b |= 2;
+            if (value.c1.x)
+                b |= 4;
+            if (value.c1.y)
+                b |= 8;
+            if (value.c2.x)
+                b |= 16;
+            if (value.c2.y)
+                b |= 32;
+
+            WriteByte(b);
+        }
+
+        public void Writebool2x4(bool2x4 value) {
+            byte b = 0;
+
+            if (value.c0.x)
+                b |= 1;
+            if (value.c0.y)
+                b |= 2;
+            if (value.c1.x)
+                b |= 4;
+            if (value.c1.y)
+                b |= 8;
+            if (value.c2.x)
+                b |= 16;
+            if (value.c2.y)
+                b |= 32;
+            if (value.c3.x)
+                b |= 64;
+            if (value.c3.y)
+                b |= 128;
+
+            WriteByte(b);
+        }
+
+        public void Writebool3x2(bool3x2 value) {
+            byte b = 0;
+
+            if (value.c0.x)
+                b |= 1;
+            if (value.c0.y)
+                b |= 2;
+            if (value.c0.z)
+                b |= 4;
+            if (value.c1.x)
+                b |= 8;
+            if (value.c1.y)
+                b |= 16;
+            if (value.c1.z)
+                b |= 32;
+
+            WriteByte(b);
+        }
+
+        public void Writebool3x3(bool3x3 value) {
+            ushort s = 0;
+
+            if (value.c0.x)
+                s |= 1;
+            if (value.c0.y)
+                s |= 2;
+            if (value.c0.z)
+                s |= 4;
+            if (value.c1.x)
+                s |= 8;
+            if (value.c1.y)
+                s |= 16;
+            if (value.c1.z)
+                s |= 32;
+            if (value.c2.x)
+                s |= 64;
+            if (value.c2.y)
+                s |= 128;
+            if (value.c2.z)
+                s |= 256;
+
+            WriteUInt16(s);
+        }
+
+        public void Writebool3x4(bool3x4 value) {
+            ushort s = 0;
+
+            if (value.c0.x)
+                s |= 1;
+            if (value.c0.y)
+                s |= 2;
+            if (value.c0.z)
+                s |= 4;
+            if (value.c1.x)
+                s |= 8;
+            if (value.c1.y)
+                s |= 16;
+            if (value.c1.z)
+                s |= 32;
+            if (value.c2.x)
+                s |= 64;
+            if (value.c2.y)
+                s |= 128;
+            if (value.c2.z)
+                s |= 256;
+            if (value.c3.x)
+                s |= 512;
+            if (value.c3.y)
+                s |= 1024;
+            if (value.c3.z)
+                s |= 2048;
+
+            WriteUInt16(s);
+        }
+
+        public void Writebool4x2(bool4x2 value) {
+            byte b = 0;
+
+            if (value.c0.x)
+                b |= 1;
+            if (value.c0.y)
+                b |= 2;
+            if (value.c0.z)
+                b |= 4;
+            if (value.c0.w)
+                b |= 8;
+            if (value.c1.x)
+                b |= 16;
+            if (value.c1.y)
+                b |= 32;
+            if (value.c1.z)
+                b |= 64;
+            if (value.c1.w)
+                b |= 128;
+
+            WriteByte(b);
+        }
+
+        public void Writebool4x3(bool4x3 value) {
+            ushort s = 0;
+
+            if (value.c0.x)
+                s |= 1;
+            if (value.c0.y)
+                s |= 2;
+            if (value.c0.z)
+                s |= 4;
+            if (value.c0.w)
+                s |= 8;
+            if (value.c1.x)
+                s |= 16;
+            if (value.c1.y)
+                s |= 32;
+            if (value.c1.z)
+                s |= 64;
+            if (value.c1.w)
+                s |= 128;
+            if (value.c2.x)
+                s |= 256;
+            if (value.c2.y)
+                s |= 512;
+            if (value.c2.z)
+                s |= 1024;
+            if (value.c2.w)
+                s |= 2048;
+
+            WriteUInt16(s);
+        }
+
+        public void Writebool4x4(bool4x4 value) {
+            ushort s = 0;
+
+            if (value.c0.x)
+                s |= 1;
+            if (value.c0.y)
+                s |= 2;
+            if (value.c0.z)
+                s |= 4;
+            if (value.c0.w)
+                s |= 8;
+            if (value.c1.x)
+                s |= 16;
+            if (value.c1.y)
+                s |= 32;
+            if (value.c1.z)
+                s |= 64;
+            if (value.c1.w)
+                s |= 128;
+            if (value.c2.x)
+                s |= 256;
+            if (value.c2.y)
+                s |= 512;
+            if (value.c2.z)
+                s |= 1024;
+            if (value.c2.w)
+                s |= 2048;
+            if (value.c3.x)
+                s |= 4096;
+            if (value.c3.y)
+                s |= 8192;
+            if (value.c3.z)
+                s |= 16384;
+            if (value.c3.w)
+                s |= 32768;
+
+            WriteUInt16(s);
+        }
+    }
+
+    public partial class Reader { 
+        public bool2 Readbool2() {
+
+            byte b = ReadByte();
+
+            return new bool2() { x = (b & 1) != 0, y = (b & 2) != 0 };
+        }
+
+        public bool3 Readbool3() {
+
+            byte b = ReadByte();
+
+            return new bool3() {
+                x = (b & 1) != 0,
+                y = (b & 2) != 0,
+                z = (b & 4) != 0
+            };
+        }
+
+        public bool4 Readbool4() {
+            byte b = ReadByte();
+
+            return new bool4 {
+                x = (b & 1) != 0,
+                y = (b & 2) != 0,
+                z = (b & 4) != 0,
+                w = (b & 8) != 0
+            };
+        }
+
+        public bool2x2 Readbool2x2() {
+            byte b = ReadByte();
+
+            bool2x2 value = default;
+
+            value.c0.x = (b & 1) != 0;
+            value.c0.y = (b & 2) != 0;
+            value.c1.x = (b & 4) != 0;
+            value.c1.y = (b & 8) != 0;
+
+            return value;
+        }
+
+        public bool2x3 Readbool2x3() {
+            byte b = ReadByte();
+
+            bool2x3 value = default;
+
+            value.c0.x = (b & 1) != 0;
+            value.c0.y = (b & 2) != 0;
+            value.c1.x = (b & 4) != 0;
+            value.c1.y = (b & 8) != 0;
+            value.c2.x = (b & 16) != 0;
+            value.c2.y = (b & 32) != 0;
+
+            return value;
+        }
+
+        public bool2x4 Readbool2x4() {
+            byte b = ReadByte();
+
+            bool2x4 value = default;
+
+            value.c0.x = (b & 1) != 0;
+            value.c0.y = (b & 2) != 0;
+            value.c1.x = (b & 4) != 0;
+            value.c1.y = (b & 8) != 0;
+            value.c2.x = (b & 16) != 0;
+            value.c2.y = (b & 32) != 0;
+            value.c3.x = (b & 64) != 0;
+            value.c3.y = (b & 128) != 0;
+
+            return value;
+        }
+
+        public bool3x2 Readbool3x2() {
+            byte b = ReadByte();
+
+            bool3x2 value = default;
+
+            value.c0.x = (b & 1) != 0;
+            value.c0.y = (b & 2) != 0;
+            value.c0.z = (b & 4) != 0;
+            value.c1.x = (b & 8) != 0;
+            value.c1.y = (b & 16) != 0;
+            value.c1.z = (b & 32) != 0;
+
+            return value;
+        }
+
+        public bool3x3 Readbool3x3() {
+            ushort s = ReadUInt16();
+
+            bool3x3 value = default;
+            value.c0.x = (s & 1) != 0;
+            value.c0.y = (s & 2) != 0;
+            value.c0.z = (s & 4) != 0;
+            value.c1.x = (s & 8) != 0;
+            value.c1.y = (s & 16) != 0;
+            value.c1.z = (s & 32) != 0;
+            value.c2.x = (s & 64) != 0;
+            value.c2.y = (s & 128) != 0;
+            value.c2.z = (s & 256) != 0;
+
+            return value;
+        }
+
+        public bool3x4 Readbool3x4() {
+            ushort s = ReadUInt16();
+
+            bool3x4 value = default;
+
+            value.c0.x = (s & 1) != 0;
+            value.c0.y = (s & 2) != 0;
+            value.c0.z = (s & 4) != 0;
+            value.c1.x = (s & 8) != 0;
+            value.c1.y = (s & 16) != 0;
+            value.c1.z = (s & 32) != 0;
+            value.c2.x = (s & 64) != 0;
+            value.c2.y = (s & 128) != 0;
+            value.c2.z = (s & 256) != 0;
+            value.c3.x = (s & 512) != 0;
+            value.c3.y = (s & 1024) != 0;
+            value.c3.z = (s & 2048) != 0;
+
+            return value;
+        }
+
+        public bool4x2 Readbool4x2() {
+            byte b = ReadByte();
+
+            bool4x2 value = default;
+
+            value.c0.x = (b & 1) != 0;
+            value.c0.y = (b & 2) != 0;
+            value.c0.z = (b & 4) != 0;
+            value.c0.w = (b & 8) != 0;
+            value.c1.x = (b & 16) != 0;
+            value.c1.y = (b & 32) != 0;
+            value.c1.z = (b & 64) != 0;
+            value.c1.w = (b & 128) != 0;
+
+            return value;
+        }
+
+        public bool4x3 Readbool4x3() {
+            ushort s = ReadUInt16();
+
+            bool4x3 value = default;
+
+            value.c0.x = (s & 1) != 0;
+            value.c0.y = (s & 2) != 0;
+            value.c0.z = (s & 4) != 0;
+            value.c0.w = (s & 8) != 0;
+            value.c1.x = (s & 16) != 0;
+            value.c1.y = (s & 32) != 0;
+            value.c1.z = (s & 64) != 0;
+            value.c1.w = (s & 128) != 0;
+            value.c2.x = (s & 256) != 0;
+            value.c2.y = (s & 512) != 0;
+            value.c2.z = (s & 1024) != 0;
+            value.c2.w = (s & 2048) != 0;
+
+            return value;
+        }
+
+        public bool4x4 Readbool4x4() {
+            ushort s = ReadUInt16();
+
+            bool4x4 value = default;
+
+            value.c0.x = (s & 1) != 0;
+            value.c0.y = (s & 2) != 0;
+            value.c0.z = (s & 4) != 0;
+            value.c0.w = (s & 8) != 0;
+            value.c1.x = (s & 16) != 0;
+            value.c1.y = (s & 32) != 0;
+            value.c1.z = (s & 64) != 0;
+            value.c1.w = (s & 128) != 0;
+            value.c2.x = (s & 256) != 0;
+            value.c2.y = (s & 512) != 0;
+            value.c2.z = (s & 1024) != 0;
+            value.c2.w = (s & 2048) != 0;
+            value.c3.x = (s & 4096) != 0;
+            value.c3.y = (s & 8192) != 0;
+            value.c3.z = (s & 16384) != 0;
+            value.c3.w = (s & 32768) != 0;
+
+            return value;
+        }
+    }
+}
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/BoolExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/BoolExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 254b9133ed0260b4685ea1d28bd15df1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/DoubleExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/DoubleExtensions.cs
@@ -1,0 +1,194 @@
+#if UNITYMATHEMATICS
+
+using System.Runtime.CompilerServices;
+
+using Unity.Mathematics;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writedouble2(double2 value) {
+            WriteDouble(value.x);
+            WriteDouble(value.y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writedouble3(double3 value) {
+            WriteDouble(value.x);
+            WriteDouble(value.y);
+            WriteDouble(value.z);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writedouble4(double4 value) {
+            WriteDouble(value.x);
+            WriteDouble(value.y);
+            WriteDouble(value.z);
+            WriteDouble(value.w);
+        }
+
+        public void Writedouble2x2(double2x2 value) {
+            Writedouble2(value.c0);
+            Writedouble2(value.c1);
+        }
+
+        public void Writedouble2x3(double2x3 value) {
+            Writedouble2(value.c0);
+            Writedouble2(value.c1);
+            Writedouble2(value.c2);
+        }
+
+        public void Writedouble2x4(double2x4 value) {
+            Writedouble2(value.c0);
+            Writedouble2(value.c1);
+            Writedouble2(value.c2);
+            Writedouble2(value.c3);
+        }
+
+        public void Writedouble3x2(double3x2 value) {
+            Writedouble3(value.c0);
+            Writedouble3(value.c1);
+        }
+
+        public void Writedouble4x2(double4x2 value) {
+            Writedouble4(value.c0);
+            Writedouble4(value.c1);
+        }
+
+        public void Writedouble3x4(double3x4 value) {
+            Writedouble3(value.c0);
+            Writedouble3(value.c1);
+            Writedouble3(value.c2);
+            Writedouble3(value.c3);
+        }
+
+        public void Writedouble4x3(double4x3 value) {
+            Writedouble4(value.c0);
+            Writedouble4(value.c1);
+            Writedouble4(value.c2);
+        }
+
+        public void Writedouble3x3(double3x3 value) {
+            Writedouble3(value.c0);
+            Writedouble3(value.c1);
+            Writedouble3(value.c2);
+        }
+        public void Writedouble4x4(double4x4 value) {
+            Writedouble4(value.c0);
+            Writedouble4(value.c1);
+            Writedouble4(value.c2);
+            Writedouble4(value.c3);
+        }
+
+    }
+
+    public partial class Reader {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double2 Readdouble2() {
+            return new double2 {
+                x = ReadDouble(),
+                y = ReadDouble()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double3 Readdouble3() {
+            return new double3() {
+                x = ReadDouble(),
+                y = ReadDouble(),
+                z = ReadDouble()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double4 Readdouble4() {
+            return new double4() {
+                x = ReadDouble(),
+                y = ReadDouble(),
+                z = ReadDouble(),
+                w = ReadDouble()
+            };
+        }
+
+        public double2x2 Readdouble2x2() {
+            return new double2x2() { 
+                c0 = Readdouble2(), 
+                c1 = Readdouble2() 
+            };
+        }
+
+
+        public double2x3 Readdouble2x3() {
+            return new double2x3() {
+                c0 = Readdouble2(),
+                c1 = Readdouble2(),
+                c2 = Readdouble2()
+            };
+        }
+
+        public double2x4 Readdouble2x4() {
+            return new double2x4() {
+                c0 = Readdouble2(),
+                c1 = Readdouble2(),
+                c2 = Readdouble2(),
+                c3 = Readdouble2()
+            };
+        }
+
+        public double3x2 Readdouble3x2() {
+            return new double3x2() {
+                c0 = Readdouble3(),
+                c1 = Readdouble3()
+            };
+        }
+
+        public double4x2 Readdouble4x2() {
+            return new double4x2() {
+                c0 = Readdouble4(),
+                c1 = Readdouble4()
+            };
+        }
+
+        public double3x4 Readdouble3x4() {
+            return new double3x4() {
+                c0 = Readdouble3(),
+                c1 = Readdouble3(),
+                c2 = Readdouble3(),
+                c3 = Readdouble3()
+            };
+        }
+
+
+        public double4x3 Readdouble4x3() {
+            return new double4x3() {
+                c0 = Readdouble4(),
+                c1 = Readdouble4(),
+                c2 = Readdouble4()
+            };
+        }
+        public double3x3 Readdouble3x3() {
+            return new double3x3() {
+                c0 = Readdouble3(),
+                c1 = Readdouble3(),
+                c2 = Readdouble3()
+            };
+        }
+
+
+        public double4x4 Readdouble4x4() {
+            return new double4x4() {
+                c0 = Readdouble4(),
+                c1 = Readdouble4(),
+                c2 = Readdouble4(),
+                c3 = Readdouble4()
+            };
+        }
+
+    }
+}
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/DoubleExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/DoubleExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b02bb31d2808f94695dfa971bbe624b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/FloatExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/FloatExtensions.cs
@@ -1,0 +1,192 @@
+#if UNITYMATHEMATICS
+
+using System.Runtime.CompilerServices;
+
+using Unity.Mathematics;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writefloat2(float2 value) {
+            WriteSingle(value.x);
+            WriteSingle(value.y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writefloat3(float3 value) {
+            WriteSingle(value.x);
+            WriteSingle(value.y);
+            WriteSingle(value.z);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writefloat4(float4 value) {
+            WriteSingle(value.x);
+            WriteSingle(value.y);
+            WriteSingle(value.z);
+            WriteSingle(value.w);
+        }
+
+        public void Writefloat2x2(float2x2 value) {
+            Writefloat2(value.c0);
+            Writefloat2(value.c1);
+        }
+
+        public void Writefloat2x3(float2x3 value) {
+            Writefloat2(value.c0);
+            Writefloat2(value.c1);
+            Writefloat2(value.c2);
+        }
+
+        public void Writefloat2x4(float2x4 value) {
+            Writefloat2(value.c0);
+            Writefloat2(value.c1);
+            Writefloat2(value.c2);
+            Writefloat2(value.c3);
+        }
+
+        public void Writefloat3x2(float3x2 value) {
+            Writefloat3(value.c0);
+            Writefloat3(value.c1);
+        }
+
+        public void Writefloat3x3(float3x3 value) {
+            Writefloat3(value.c0);
+            Writefloat3(value.c1);
+            Writefloat3(value.c2);
+        }
+
+        public void Writefloat3x4(float3x4 value) {
+            Writefloat3(value.c0);
+            Writefloat3(value.c1);
+            Writefloat3(value.c2);
+            Writefloat3(value.c3);
+        }
+
+        public void Writefloat4x2(float4x2 value) {
+            Writefloat4(value.c0);
+            Writefloat4(value.c1);
+        }
+
+        public void Writefloat4x3(float4x3 value) {
+            Writefloat4(value.c0);
+            Writefloat4(value.c1);
+            Writefloat4(value.c2);
+        }
+
+        public void Writefloat4x4(float4x4 value) {
+            Writefloat4(value.c0);
+            Writefloat4(value.c1);
+            Writefloat4(value.c2);
+            Writefloat4(value.c3);
+        }
+
+    }
+
+    public partial class Reader {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float2 Readfloat2() {
+            return new float2 {
+                x = ReadSingle(),
+                y = ReadSingle()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float3 Readfloat3() {
+            return new float3() {
+                x = ReadSingle(),
+                y = ReadSingle(),
+                z = ReadSingle()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float4 Readfloat4() {
+            return new float4() {
+                x = ReadSingle(),
+                y = ReadSingle(),
+                z = ReadSingle(),
+                w = ReadSingle()
+            };
+        }
+
+        public float2x2 Readfloat2x2() {
+            return new float2x2() { 
+                c0 = Readfloat2(), 
+                c1 = Readfloat2() };
+        }
+
+        public float2x3 Readfloat2x3() {
+            return new float2x3() {
+                c0 = Readfloat2(),
+                c1 = Readfloat2(),
+                c2 = Readfloat2()
+            };
+        }
+
+        public float2x4 Readfloat2x4() {
+            return new float2x4() {
+                c0 = Readfloat2(),
+                c1 = Readfloat2(),
+                c2 = Readfloat2(),
+                c3 = Readfloat2()
+            };
+        }
+
+        public float3x2 Readfloat3x2() {
+            return new float3x2() {
+                c0 = Readfloat3(),
+                c1 = Readfloat3()
+            };
+        }
+
+        public float3x3 Readfloat3x3() {
+            return new float3x3() {
+                c0 = Readfloat3(),
+                c1 = Readfloat3(),
+                c2 = Readfloat3()
+            };
+        }
+
+        public float3x4 Readfloat3x4() {
+            return new float3x4() {
+                c0 = Readfloat3(),
+                c1 = Readfloat3(),
+                c2 = Readfloat3(),
+                c3 = Readfloat3()
+            };
+        }
+
+        public float4x2 Readfloat4x2() {
+            return new float4x2() {
+                c0 = Readfloat4(),
+                c1 = Readfloat4()
+            };
+        }
+
+        public float4x3 Readfloat4x3() {
+            return new float4x3() {
+                c0 = Readfloat4(),
+                c1 = Readfloat4(),
+                c2 = Readfloat4()
+            };
+        }
+
+        public float4x4 Readfloat4x4() {
+            return new float4x4() {
+                c0 = Readfloat4(),
+                c1 = Readfloat4(),
+                c2 = Readfloat4(),
+                c3 = Readfloat4()
+            };
+        }
+
+    }
+}
+
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/FloatExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/FloatExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 501c2baf76f23f64fadc0fd46e2d95fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/HalfExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/HalfExtensions.cs
@@ -1,0 +1,84 @@
+#if UNITYMATHEMATICS
+
+using System.Runtime.CompilerServices;
+
+using Unity.Mathematics;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writehalf(half value) {
+            WriteUInt16(value.value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writehalf2(half2 value) {
+            WriteUInt16(value.x.value);
+            WriteUInt16(value.y.value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writehalf3(half3 value) {
+            WriteUInt16(value.x.value);
+            WriteUInt16(value.y.value);
+            WriteUInt16(value.z.value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writehalf4(half4 value) {
+
+            WriteUInt16(value.x.value);
+            WriteUInt16(value.y.value);
+            WriteUInt16(value.z.value);
+            WriteUInt16(value.w.value);
+        }
+    }
+
+    public partial class Reader {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public half Readhalf() { 
+            return new half { value = ReadUInt16() };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public half2 Readhalf2() {
+
+            half2 h = default;
+
+            h.x.value = ReadUInt16();
+            h.y.value = ReadUInt16();
+
+            return h;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public half3 Readhalf3() {
+
+            half3 h = default;
+            
+            h.x.value = ReadUInt16();
+            h.y.value = ReadUInt16();
+            h.z.value = ReadUInt16();
+
+            return h;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public half4 Readhalf4() {
+
+            half4 h = default;
+
+            h.x.value = ReadUInt16();
+            h.y.value = ReadUInt16();
+            h.z.value = ReadUInt16();
+            h.w.value = ReadUInt16();
+
+            return h;
+        }
+    }
+}
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/HalfExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/HalfExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eeb83ce2d1531bc4ea314600a3978c79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/IntExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/IntExtensions.cs
@@ -1,0 +1,190 @@
+#if UNITYMATHEMATICS
+
+using System.Runtime.CompilerServices;
+using Unity.Mathematics;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writeint2(int2 value) {
+            WriteInt32(value.x);
+            WriteInt32(value.y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writeint3(int3 value) {
+            WriteInt32(value.x);
+            WriteInt32(value.y);
+            WriteInt32(value.z);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writeint4(int4 value) {
+            WriteInt32(value.x);
+            WriteInt32(value.y);
+            WriteInt32(value.z);
+            WriteInt32(value.w);
+        }
+
+        public void Writeint2x2(int2x2 value) {
+            Writeint2(value.c0);
+            Writeint2(value.c1);
+        }
+
+        public void Writeint2x3(int2x3 value) {
+            Writeint2(value.c0);
+            Writeint2(value.c1);
+            Writeint2(value.c2);
+        }
+
+        public void Writeint2x4(int2x4 value) {
+            Writeint2(value.c0);
+            Writeint2(value.c1);
+            Writeint2(value.c2);
+            Writeint2(value.c3);
+        }
+
+        public void Writeint3x2(int3x2 value) {
+            Writeint3(value.c0);
+            Writeint3(value.c1);
+        }
+
+        public void Writeint3x3(int3x3 value) {
+            Writeint3(value.c0);
+            Writeint3(value.c1);
+            Writeint3(value.c2);
+        }
+
+        public void Writeint3x4(int3x4 value) {
+            Writeint3(value.c0);
+            Writeint3(value.c1);
+            Writeint3(value.c2);
+            Writeint3(value.c3);
+        }
+
+        public void Writeint4x2(int4x2 value) {
+            Writeint4(value.c0);
+            Writeint4(value.c1);
+        }
+
+        public void Writeint4x3(int4x3 value) {
+            Writeint4(value.c0);
+            Writeint4(value.c1);
+            Writeint4(value.c2);
+        }
+
+        public void Writeint4x4(int4x4 value) {
+            Writeint4(value.c0);
+            Writeint4(value.c1);
+            Writeint4(value.c2);
+            Writeint4(value.c3);
+        }
+
+    }
+
+    public partial class Reader {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int2 Readint2() {
+            return new int2 {
+                x = ReadInt32(),
+                y = ReadInt32()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int3 Readint3() {
+            return new int3() {
+                x = ReadInt32(),
+                y = ReadInt32(),
+                z = ReadInt32()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int4 Readint4() {
+            return new int4() {
+                x = ReadInt32(),
+                y = ReadInt32(),
+                z = ReadInt32(),
+                w = ReadInt32()
+            };
+        }
+
+        public int2x2 Readint2x2() {
+            return new int2x2() { 
+                c0 = Readint2(), 
+                c1 = Readint2() };
+        }
+
+        public int2x3 Readint2x3() {
+            return new int2x3() {
+                c0 = Readint2(),
+                c1 = Readint2(),
+                c2 = Readint2()
+            };
+        }
+
+        public int2x4 Readint2x4() {
+            return new int2x4() {
+                c0 = Readint2(),
+                c1 = Readint2(),
+                c2 = Readint2(),
+                c3 = Readint2()
+            };
+        }
+
+        public int3x2 Readint3x2() {
+            return new int3x2() {
+                c0 = Readint3(),
+                c1 = Readint3()
+            };
+        }
+
+        public int3x3 Readint3x3() {
+            return new int3x3() {
+                c0 = Readint3(),
+                c1 = Readint3(),
+                c2 = Readint3()
+            };
+        }
+
+        public int3x4 Readint3x4() {
+            return new int3x4() {
+                c0 = Readint3(),
+                c1 = Readint3(),
+                c2 = Readint3(),
+                c3 = Readint3()
+            };
+        }
+
+        public int4x2 Readint4x2() {
+            return new int4x2() {
+                c0 = Readint4(),
+                c1 = Readint4()
+            };
+        }
+
+        public int4x3 Readint4x3() {
+            return new int4x3() {
+                c0 = Readint4(),
+                c1 = Readint4(),
+                c2 = Readint4()
+            };
+        }
+
+        public int4x4 Readint4x4() {
+            return new int4x4() {
+                c0 = Readint4(),
+                c1 = Readint4(),
+                c2 = Readint4(),
+                c3 = Readint4()
+            };
+        }
+
+    }
+}
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/IntExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/IntExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74baebf467113dd4ca83dd656a4abb67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/OtherExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/OtherExtensions.cs
@@ -1,0 +1,86 @@
+#if UNITYMATHEMATICS
+
+using System.Runtime.CompilerServices;
+using Unity.Mathematics;
+using Unity.Mathematics.Geometry;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writequaternion(quaternion value) {
+            Writefloat4(value.value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writerandom(Unity.Mathematics.Random random) {
+            WriteUInt32(random.state);
+        }
+
+        public void WriteRigidTransform(RigidTransform value) {
+
+            Writequaternion(value.rot);
+            Writefloat3(value.pos);
+        }
+#if UNITYMATHEMATICS_131
+        public void WriteAffineTransform(AffineTransform value) {
+
+            Writefloat3x3(value.rs);
+            Writefloat3(value.t);
+        }
+#endif
+
+#if UNITYMATHEMATICS_132
+
+        public void ReadMinMaxAABB(MinMaxAABB minMaxAABB) {
+            Writefloat3(minMaxAABB.Min);
+            Writefloat3(minMaxAABB.Max);
+        }
+
+#endif
+    }
+
+    public partial class Reader {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public quaternion Readquaternion() {
+            return new quaternion(Readfloat4());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Random Readrandom() {
+            return new Random() { state = ReadUInt32() };
+        }
+
+        public RigidTransform ReadRigidTransform() {
+            return new RigidTransform() {
+                rot = Readquaternion(),
+                pos = Readfloat3(),
+            };
+        }
+
+#if UNITYMATHEMATICS_131
+        public AffineTransform ReadAffineTransform() {
+
+            return new AffineTransform() {
+                rs = Readfloat3x3(),
+                t = Readfloat3(),
+            };
+        }
+#endif
+
+#if UNITYMATHEMATICS_132
+
+        public MinMaxAABB ReadMinMaxAABB() {
+            return new MinMaxAABB() {
+
+                Min = Readfloat3(),
+                Max = Readfloat3()
+            };
+        }
+#endif
+    }
+}
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/OtherExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/OtherExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34d28436e6d87044fa5dcd3b0b7fd097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/UIntExtensions.cs
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/UIntExtensions.cs
@@ -1,0 +1,190 @@
+#if UNITYMATHEMATICS
+
+using System.Runtime.CompilerServices;
+using Unity.Mathematics;
+
+namespace FishNet.Serializing {
+
+    public partial class Writer {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writeuint2(uint2 value) {
+            WriteUInt32(value.x);
+            WriteUInt32(value.y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writeuint3(uint3 value) {
+            WriteUInt32(value.x);
+            WriteUInt32(value.y);
+            WriteUInt32(value.z);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Writeuint4(uint4 value) {
+            WriteUInt32(value.x);
+            WriteUInt32(value.y);
+            WriteUInt32(value.z);
+            WriteUInt32(value.w);
+        }
+
+        public void Writeuint2x2(uint2x2 value) {
+            Writeuint2(value.c0);
+            Writeuint2(value.c1);
+        }
+
+        public void Writeuint2x3(uint2x3 value) {
+            Writeuint2(value.c0);
+            Writeuint2(value.c1);
+            Writeuint2(value.c2);
+        }
+
+        public void Writeuint2x4(uint2x4 value) {
+            Writeuint2(value.c0);
+            Writeuint2(value.c1);
+            Writeuint2(value.c2);
+            Writeuint2(value.c3);
+        }
+
+        public void Writeuint3x2(uint3x2 value) {
+            Writeuint3(value.c0);
+            Writeuint3(value.c1);
+        }
+
+        public void Writeuint3x3(uint3x3 value) {
+            Writeuint3(value.c0);
+            Writeuint3(value.c1);
+            Writeuint3(value.c2);
+        }
+
+        public void Writeuint3x4(uint3x4 value) {
+            Writeuint3(value.c0);
+            Writeuint3(value.c1);
+            Writeuint3(value.c2);
+            Writeuint3(value.c3);
+        }
+
+        public void Writeuint4x2(uint4x2 value) {
+            Writeuint4(value.c0);
+            Writeuint4(value.c1);
+        }
+
+        public void Writeuint4x3(uint4x3 value) {
+            Writeuint4(value.c0);
+            Writeuint4(value.c1);
+            Writeuint4(value.c2);
+        }
+
+        public void Writeuint4x4(uint4x4 value) {
+            Writeuint4(value.c0);
+            Writeuint4(value.c1);
+            Writeuint4(value.c2);
+            Writeuint4(value.c3);
+        }
+
+    }
+
+    public partial class Reader {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint2 Readuint2() {
+            return new uint2 {
+                x = ReadUInt32(),
+                y = ReadUInt32()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint3 Readuint3() {
+            return new uint3() {
+                x = ReadUInt32(),
+                y = ReadUInt32(),
+                z = ReadUInt32()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint4 Readuint4() {
+            return new uint4() {
+                x = ReadUInt32(),
+                y = ReadUInt32(),
+                z = ReadUInt32(),
+                w = ReadUInt32()
+            };
+        }
+
+        public uint2x2 Readuint2x2() {
+            return new uint2x2() { 
+                c0 = Readuint2(), 
+                c1 = Readuint2() };
+        }
+
+        public uint2x3 Readuint2x3() {
+            return new uint2x3() {
+                c0 = Readuint2(),
+                c1 = Readuint2(),
+                c2 = Readuint2()
+            };
+        }
+
+        public uint2x4 Readuint2x4() {
+            return new uint2x4() {
+                c0 = Readuint2(),
+                c1 = Readuint2(),
+                c2 = Readuint2(),
+                c3 = Readuint2()
+            };
+        }
+
+        public uint3x2 Readuint3x2() {
+            return new uint3x2() {
+                c0 = Readuint3(),
+                c1 = Readuint3()
+            };
+        }
+
+        public uint3x3 Readuint3x3() {
+            return new uint3x3() {
+                c0 = Readuint3(),
+                c1 = Readuint3(),
+                c2 = Readuint3()
+            };
+        }
+
+        public uint3x4 Readuint3x4() {
+            return new uint3x4() {
+                c0 = Readuint3(),
+                c1 = Readuint3(),
+                c2 = Readuint3(),
+                c3 = Readuint3()
+            };
+        }
+
+        public uint4x2 Readuint4x2() {
+            return new uint4x2() {
+                c0 = Readuint4(),
+                c1 = Readuint4()
+            };
+        }
+
+        public uint4x3 Readuint4x3() {
+            return new uint4x3() {
+                c0 = Readuint4(),
+                c1 = Readuint4(),
+                c2 = Readuint4()
+            };
+        }
+
+        public uint4x4 Readuint4x4() {
+            return new uint4x4() {
+                c0 = Readuint4(),
+                c1 = Readuint4(),
+                c2 = Readuint4(),
+                c3 = Readuint4()
+            };
+        }
+
+    }
+}
+
+#endif

--- a/Assets/FishNet/Runtime/Serializing/MathExtensions/UIntExtensions.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/MathExtensions/UIntExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5640c6f5fc37ed3419f18024866c816c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/UnityMathematicsSerializationTest.meta
+++ b/Assets/FishNet/UnityMathematicsSerializationTest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 736465b9f2cee2e479d3482894ea0034
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/UnityMathematicsSerializationTest/MathTestStruct.cs
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/MathTestStruct.cs
@@ -1,0 +1,229 @@
+using System;
+
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Mathematics.Geometry;
+
+
+//[FishNet.CodeGenerating.IncludeSerialization]
+public struct MathTestStruct {
+
+        public bool2 b2;
+        public bool3 b3;
+        public bool4 b4;
+
+        public bool2x2 b2x2;
+        public bool2x3 b2x3;
+        public bool2x4 b2x4;
+
+        public bool3x2 b3x2;
+        public bool3x3 b3x3;
+        public bool3x4 b3x4;
+
+        public bool4x2 b4x2;
+        public bool4x3 b4x3;
+        public bool4x4 b4x4;
+
+
+        public int2 i2;
+        public int3 i3;
+        public int4 i4;
+
+        public int2x2 i2x2;
+        public int2x3 i2x3;
+        public int2x4 i2x4;
+
+        public int3x2 i3x2;
+        public int3x3 i3x3;
+        public int3x4 i3x4;
+
+        public int4x2 i4x2;
+        public int4x3 i4x3;
+        public int4x4 i4x4;
+
+
+        public uint2 ui2;
+        public uint3 ui3;
+        public uint4 ui4;
+
+        public uint2x2 ui2x2;
+        public uint2x3 ui2x3;
+        public uint2x4 ui2x4;
+
+        public uint3x2 ui3x2;
+        public uint3x3 ui3x3;
+        public uint3x4 ui3x4;
+
+        public uint4x2 ui4x2;
+        public uint4x3 ui4x3;
+        public uint4x4 ui4x4;
+
+
+        public float2 f2;
+        public float3 f3;
+        public float4 f4;
+
+        public float2x2 f2x2;
+        public float2x3 f2x3;
+        public float2x4 f2x4;
+
+        public float3x2 f3x2;
+        public float3x3 f3x3;
+        public float3x4 f3x4;
+
+        public float4x2 f4x2;
+        public float4x3 f4x3;
+        public float4x4 f4x4;
+
+
+        public double2 d2;
+        public double3 d3;
+        public double4 d4;
+
+        public double2x2 d2x2;
+        public double2x3 d2x3;
+        public double2x4 d2x4;
+
+        public double3x2 d3x2;
+        public double3x3 d3x3;
+        public double3x4 d3x4;
+
+        public double4x2 d4x2;
+        public double4x3 d4x3;
+        public double4x4 d4x4;
+
+
+        public half2 h2;
+        public half3 h3;
+        public half4 h4;
+
+        public quaternion quaternion;
+
+        public Unity.Mathematics.Random random;
+
+        public RigidTransform transform;
+
+#if UNITYMATHEMATICS_131
+        public AffineTransform affineTransform;
+#endif
+
+#if UNITYMATHEMATICS_132
+        public MinMaxAABB aabb;
+#endif
+
+    public static MathTestStruct GenerateFromSeed(uint seed) {
+
+            Unity.Mathematics.Random rand = new Unity.Mathematics.Random(seed);
+
+            return new MathTestStruct() {
+
+                // BOOL
+                b2 = rand.NextBool2(),
+                b3 = rand.NextBool3(),
+                b4 = rand.NextBool4(),
+
+                b2x2 = new(rand.NextBool2(), rand.NextBool2()),
+                b2x3 = new(rand.NextBool2(), rand.NextBool2(), rand.NextBool2()),
+                b2x4 = new(rand.NextBool2(), rand.NextBool2(), rand.NextBool2(), rand.NextBool2()),
+
+                b3x2 = new(rand.NextBool3(), rand.NextBool3()),
+                b3x3 = new(rand.NextBool3(), rand.NextBool3(), rand.NextBool3()),
+                b3x4 = new(rand.NextBool3(), rand.NextBool3(), rand.NextBool3(), rand.NextBool3()),
+
+                b4x2 = new(rand.NextBool4(), rand.NextBool4()),
+                b4x3 = new(rand.NextBool4(), rand.NextBool4(), rand.NextBool4()),
+                b4x4 = new(rand.NextBool4(), rand.NextBool4(), rand.NextBool4(), rand.NextBool4()),
+
+                // FLOAT
+                f2 = rand.NextFloat2(),
+                f3 = rand.NextFloat3(),
+                f4 = rand.NextFloat4(),
+
+                f2x2 = new(rand.NextFloat2(), rand.NextFloat2()),
+                f2x3 = new(rand.NextFloat2(), rand.NextFloat2(), rand.NextFloat2()),
+                f2x4 = new(rand.NextFloat2(), rand.NextFloat2(), rand.NextFloat2(), rand.NextFloat2()),
+
+                f3x2 = new(rand.NextFloat3(), rand.NextFloat3()),
+                f3x3 = new(rand.NextFloat3(), rand.NextFloat3(), rand.NextFloat3()),
+                f3x4 = new(rand.NextFloat3(), rand.NextFloat3(), rand.NextFloat3(), rand.NextFloat3()),
+
+                f4x2 = new(rand.NextFloat4(), rand.NextFloat4()),
+                f4x3 = new(rand.NextFloat4(), rand.NextFloat4(), rand.NextFloat4()),
+                f4x4 = new(rand.NextFloat4(), rand.NextFloat4(), rand.NextFloat4(), rand.NextFloat4()),
+
+                // DOUBLE
+                d2 = rand.NextDouble2(),
+                d3 = rand.NextDouble3(),
+                d4 = rand.NextDouble4(),
+
+                d2x2 = new(rand.NextDouble2(), rand.NextDouble2()),
+                d2x3 = new(rand.NextDouble2(), rand.NextDouble2(), rand.NextDouble2()),
+                d2x4 = new(rand.NextDouble2(), rand.NextDouble2(), rand.NextDouble2(), rand.NextDouble2()),
+
+                d3x2 = new(rand.NextDouble3(), rand.NextDouble3()),
+                d3x3 = new(rand.NextDouble3(), rand.NextDouble3(), rand.NextDouble3()),
+                d3x4 = new(rand.NextDouble3(), rand.NextDouble3(), rand.NextDouble3(), rand.NextDouble3()),
+
+                d4x2 = new(rand.NextDouble4(), rand.NextDouble4()),
+                d4x3 = new(rand.NextDouble4(), rand.NextDouble4(), rand.NextDouble4()),
+                d4x4 = new(rand.NextDouble4(), rand.NextDouble4(), rand.NextDouble4(), rand.NextDouble4()),
+
+                // INT
+                i2 = rand.NextInt2(),
+                i3 = rand.NextInt3(),
+                i4 = rand.NextInt4(),
+
+                i2x2 = new(rand.NextInt2(), rand.NextInt2()),
+                i2x3 = new(rand.NextInt2(), rand.NextInt2(), rand.NextInt2()),
+                i2x4 = new(rand.NextInt2(), rand.NextInt2(), rand.NextInt2(), rand.NextInt2()),
+
+                i3x2 = new(rand.NextInt3(), rand.NextInt3()),
+                i3x3 = new(rand.NextInt3(), rand.NextInt3(), rand.NextInt3()),
+                i3x4 = new(rand.NextInt3(), rand.NextInt3(), rand.NextInt3(), rand.NextInt3()),
+
+                i4x2 = new(rand.NextInt4(), rand.NextInt4()),
+                i4x3 = new(rand.NextInt4(), rand.NextInt4(), rand.NextInt4()),
+                i4x4 = new(rand.NextInt4(), rand.NextInt4(), rand.NextInt4(), rand.NextInt4()),
+
+                ui2 = rand.NextUInt2(),
+                ui3 = rand.NextUInt3(),
+                ui4 = rand.NextUInt4(),
+
+                // UINT
+                ui2x2 = new(rand.NextUInt2(), rand.NextUInt2()),
+                ui2x3 = new(rand.NextUInt2(), rand.NextUInt2(), rand.NextUInt2()),
+                ui2x4 = new(rand.NextUInt2(), rand.NextUInt2(), rand.NextUInt2(), rand.NextUInt2()),
+
+                ui3x2 = new(rand.NextUInt3(), rand.NextUInt3()),
+                ui3x3 = new(rand.NextUInt3(), rand.NextUInt3(), rand.NextUInt3()),
+                ui3x4 = new(rand.NextUInt3(), rand.NextUInt3(), rand.NextUInt3(), rand.NextUInt3()),
+
+                ui4x2 = new(rand.NextUInt4(), rand.NextUInt4()),
+                ui4x3 = new(rand.NextUInt4(), rand.NextUInt4(), rand.NextUInt4()),
+                ui4x4 = new(rand.NextUInt4(), rand.NextUInt4(), rand.NextUInt4(), rand.NextUInt4()),
+
+                // HALF
+                h2 = new half2(rand.NextFloat2Direction()),
+                h3 = new half3(rand.NextFloat3Direction()),
+                h4 = new half4(rand.NextFloat()),
+
+                // OTHER
+                quaternion = rand.NextQuaternionRotation(),
+
+                transform = new RigidTransform(rand.NextQuaternionRotation(), rand.NextFloat3Direction()),
+
+                random = new Unity.Mathematics.Random(seed),
+
+
+#if UNITYMATHEMATICS_131
+        affineTransform = new AffineTransform(rand.NextFloat3Direction(), rand.NextQuaternionRotation()),
+#endif
+
+#if UNITYMATHEMATICS_132
+        aabb = new MinMaxAABB(rand.NextFloat(), rand.NextFloat())
+#endif
+            };
+        }
+
+
+    }

--- a/Assets/FishNet/UnityMathematicsSerializationTest/MathTestStruct.cs.meta
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/MathTestStruct.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f28cfa47c42b0c4f839ebbd1ad5fae3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsSerializationTest.unity
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsSerializationTest.unity
@@ -1,0 +1,846 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &615342847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 615342850}
+  - component: {fileID: 615342849}
+  - component: {fileID: 615342851}
+  m_Layer: 0
+  m_Name: UnityMathSerializationTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &615342849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <IsNested>k__BackingField: 0
+  <ComponentIndex>k__BackingField: 0
+  <PredictedSpawn>k__BackingField: {fileID: 0}
+  _networkBehaviours:
+  - {fileID: 615342851}
+  <SerializedRootNetworkBehaviour>k__BackingField: {fileID: 0}
+  <NestedRootNetworkBehaviours>k__BackingField: []
+  SerializedTransformProperties:
+    Position: {x: 0, y: 0, z: 0}
+    Rotation: {x: 0, y: 0, z: 0, w: 1}
+    LocalScale: {x: 1, y: 1, z: 1}
+  _isNetworked: 1
+  _isSpawnable: 1
+  _isGlobal: 0
+  _initializeOrder: 0
+  _defaultDespawnType: 0
+  NetworkObserver: {fileID: 0}
+  _enablePrediction: 0
+  _predictionType: 0
+  _graphicalObject: {fileID: 0}
+  _enableStateForwarding: 1
+  _networkTransform: {fileID: 0}
+  _ownerInterpolation: 1
+  _enableTeleport: 0
+  _teleportThreshold: 1
+  <PrefabId>k__BackingField: 0
+  <SpawnableCollectionId>k__BackingField: 0
+  _scenePathHash: 2490358215
+  <SceneId>k__BackingField: 10696007092120705784
+  <AssetPathHash>k__BackingField: 0
+--- !u!4 &615342850
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &615342851
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f4f840d2aadd841a536ff1d53b6398, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 0
+  _addedNetworkObject: {fileID: 615342849}
+  _networkObjectCache: {fileID: 615342849}
+--- !u!114 &31255994101980119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8492223723419120170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.25490198, g: 0.25490198, b: 0.25490198, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b3dca501a9d8c8479dc71dd068aa8b8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!223 &833561939391683936
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &833561939391683937
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 833561939412960708}
+  - {fileID: 833561939932868676}
+  m_Father: {fileID: 5776661931769733468}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &833561939391683938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &833561939391683939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!1 &833561939391683964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 833561939391683937}
+  - component: {fileID: 833561939391683965}
+  - component: {fileID: 833561939391683936}
+  - component: {fileID: 833561939391683939}
+  - component: {fileID: 833561939391683938}
+  m_Layer: 5
+  m_Name: NetworkHudCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &833561939391683965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d3606bfdac5a4743890fc1a5ecd8f24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _autoStartType: 1
+  _stoppedColor: {r: 0.25490198, g: 0.25490198, b: 0.25490198, a: 1}
+  _changingColor: {r: 0.78431374, g: 0.6862745, b: 0, a: 1}
+  _startedColor: {r: 0, g: 0.5882353, b: 0.64705884, a: 1}
+  _serverIndicator: {fileID: 31255994101980119}
+  _clientIndicator: {fileID: 2640692993215481821}
+--- !u!224 &833561939412960708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5982800601722334148}
+  m_Father: {fileID: 833561939391683937}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 16, y: -16}
+  m_SizeDelta: {x: 256, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &833561939412960709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 833561939412960714}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 833561939391683965}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: OnClick_Server
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &833561939412960711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 833561939412960708}
+  - component: {fileID: 833561939412960715}
+  - component: {fileID: 833561939412960714}
+  - component: {fileID: 833561939412960709}
+  m_Layer: 5
+  m_Name: Server
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &833561939412960714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1b187e63031bf7849b249c8212440c3b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &833561939412960715
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_CullTransparentMesh: 0
+--- !u!224 &833561939932868676
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5310255346163286054}
+  m_Father: {fileID: 833561939391683937}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 16, y: -96}
+  m_SizeDelta: {x: 256, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &833561939932868677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 833561939932868682}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 833561939391683965}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: OnClick_Client
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &833561939932868679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 833561939932868676}
+  - component: {fileID: 833561939932868683}
+  - component: {fileID: 833561939932868682}
+  - component: {fileID: 833561939932868677}
+  m_Layer: 5
+  m_Name: Client
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &833561939932868682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2d50394614f8feb4eb0567fb7618d84d, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &833561939932868683
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_CullTransparentMesh: 0
+--- !u!1 &1516907665569361716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5310255346163286054}
+  - component: {fileID: 7708060694241303342}
+  - component: {fileID: 2640692993215481821}
+  m_Layer: 5
+  m_Name: Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2640692993215481821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516907665569361716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.25490198, g: 0.25490198, b: 0.25490198, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b3dca501a9d8c8479dc71dd068aa8b8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &5310255346163286054
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516907665569361716}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 833561939932868676}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!4 &5776661931769733468
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 833561939391683937}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5776661931769733470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5776661931769733468}
+  - component: {fileID: 5776661931769733471}
+  - component: {fileID: 5776661931769733472}
+  - component: {fileID: 5776661931769733473}
+  m_Layer: 0
+  m_Name: NetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &5776661931769733471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c95dfde7d73b54dbbdc23155d35d36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _refreshDefaultPrefabs: 0
+  _runInBackground: 1
+  _dontDestroyOnLoad: 1
+  _objectPool: {fileID: 0}
+  _persistence: 0
+  _logging: {fileID: 0}
+  _spawnablePrefabs: {fileID: 11400000, guid: 3a72037bac3462143a80cbc39336c3e9, type: 2}
+--- !u!114 &5776661931769733472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e08bb003fce297d4086cf8cba5aa459a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _dropExcessiveReplicates: 1
+  _maximumServerReplicates: 15
+  _interpolation: 2
+  _allowPredictedSpawning: 1
+  _reservedObjectIds: 15
+--- !u!114 &5776661931769733473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f48f002b825cbd45a19bd96d90f9edb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _dontRoute: 0
+  _unreliableMtu: 1023
+  _ipv4BindAddress: 
+  _enableIpv6: 1
+  _ipv6BindAddress: 
+  _port: 7770
+  _maximumClients: 4095
+  _clientAddress: localhost
+--- !u!224 &5982800601722334148
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8492223723419120170}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 833561939412960708}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7708060694241303342
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516907665569361716}
+  m_CullTransparentMesh: 0
+--- !u!222 &8192313925857261485
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8492223723419120170}
+  m_CullTransparentMesh: 0
+--- !u!1 &8492223723419120170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5982800601722334148}
+  - component: {fileID: 8192313925857261485}
+  - component: {fileID: 31255994101980119}
+  m_Layer: 5
+  m_Name: Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 5776661931769733468}
+  - {fileID: 615342850}

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsSerializationTest.unity
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsSerializationTest.unity
@@ -176,8 +176,8 @@ MonoBehaviour:
   _teleportThreshold: 1
   <PrefabId>k__BackingField: 0
   <SpawnableCollectionId>k__BackingField: 0
-  _scenePathHash: 2490358215
-  <SceneId>k__BackingField: 10696007092120705784
+  _scenePathHash: 1905127121
+  <SceneId>k__BackingField: 8182458681646870828
   <AssetPathHash>k__BackingField: 0
 --- !u!4 &615342850
 Transform:

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsSerializationTest.unity.meta
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsSerializationTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 47437d4bba130b049b515708a08f6f2f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.asmdef
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.asmdef
@@ -1,24 +1,18 @@
 {
-    "name": "FishNet.Runtime",
+    "name": "UnityMathematicsTest",
     "rootNamespace": "",
     "references": [
-        "GUID:894a6cc6ed5cd2645bb542978cbed6a9",
-        "GUID:1d82bdf40e2465b44b34adf79595e74c",
+        "GUID:7c88a4a7926ee5145ad2dfa06f454c67",
         "GUID:d8b63aba1907145bea998dd612889d6b"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": true,
+    "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [
-        {
-            "name": "com.veriorpies.parrelsync",
-            "expression": "1.2",
-            "define": "PARRELSYNC"
-        },
         {
             "name": "com.unity.mathematics",
             "expression": "1.2.6",
@@ -27,12 +21,12 @@
         {
             "name": "com.unity.mathematics",
             "expression": "1.3.1",
-            "define": "UNITYMATHEMATICS131"
+            "define": "UNITYMATHEMATICS_131"
         },
         {
             "name": "com.unity.mathematics",
             "expression": "1.3.2",
-            "define": "UNITYMATHEMATICS132"
+            "define": "UNITYMATHEMATICS_132"
         }
     ],
     "noEngineReferences": false

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.asmdef.meta
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 96f7d05229063f34bb9ead462d0fd8c8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.cs
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.cs
@@ -1,0 +1,87 @@
+using FishNet.Connection;
+using FishNet.Object;
+
+using UnityEngine;
+using Unity.Mathematics;
+using FishNet.Serializing;
+using System.Collections.Generic;
+using System;
+using System.Runtime.InteropServices;
+
+
+public class UnityMathematicsTest : NetworkBehaviour {
+
+    private void Awake() {
+        Debug.Log($"Size of test struct: {Marshal.SizeOf<MathTestStruct>()} in bytes");
+    }
+
+    const int sendsCound = 100;
+
+    
+
+    private void FixedUpdate() {
+         
+        if (IsHostInitialized) {
+
+            uint seed = this.TimeManager.Tick;
+
+            var random = new Unity.Mathematics.Random(seed);
+
+            var writer = WriterPool.Retrieve(this.NetworkManager, 2050 * sendsCound + 8);
+
+            for (int i = 0; i < sendsCound; i++) {
+
+                uint innerSeed = random.NextUInt();
+
+                var testData = MathTestStruct.GenerateFromSeed(innerSeed);
+
+                writer.Write<MathTestStruct>(testData);
+            }
+
+            TestSerializationRPC(seed, writer.GetArraySegment());
+
+            WriterPool.StoreLength(writer);
+            
+        }   
+    }
+
+    // never to be called, just to activate serializer autogen for the struct (no way to force auto gen serializer yet)
+    [ServerRpc()]
+    private void NeverToBeCalledRPC(MathTestStruct x)
+    {
+
+    }
+    [ServerRpc(RequireOwnership = false, DataLength = 2040 * sendsCound + 4)]
+    private void TestSerializationRPC(uint seed, ArraySegment<byte> data, NetworkConnection conn = null) {
+
+        var random = new Unity.Mathematics.Random(seed);
+
+        var reader = ReaderPool.Retrieve(data, this.NetworkManager);
+
+        for (int i = 0; i < sendsCound; i++) {
+
+            uint innerSeed = random.NextUInt();
+
+            var receivedData = reader.Read<MathTestStruct>();
+                
+            var testData = MathTestStruct.GenerateFromSeed(innerSeed);
+
+            if (!IsEqual(receivedData, testData)) {
+                UnityEngine.Debug.LogError("Data does not match! Serialization faulty");
+            }
+            else {
+                UnityEngine.Debug.Log("All fine!");
+            } 
+        }
+
+        ReaderPool.Store(reader);
+
+    }
+
+
+    // just compare struct by value
+    private bool IsEqual(MathTestStruct a, MathTestStruct b) {
+
+        return EqualityComparer<MathTestStruct>.Default.Equals(a, b);
+    }
+}

--- a/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.cs.meta
+++ b/Assets/FishNet/UnityMathematicsSerializationTest/UnityMathematicsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0f4f840d2aadd841a536ff1d53b6398
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Written serializers for Unity Mathematics types, almost all except `Plane`, which cannot be done (same named struct already exists).

Included test.

Requires adding defines to Fishnet.Runtime in order to enable code if Unity.Mathematics is present.

![image](https://github.com/FirstGearGames/FishNet/assets/4028544/cace835b-a94c-427d-8113-13a545fb6a79)
