### PR TITLE
Avoid Activator.CreateInstance()

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
@@ -1119,7 +1119,7 @@ namespace FishNet.Component.Transforming
         /// <summary>
         /// Stores an object if it has value then sets it to default.
         /// </summary>
-        private void StoreObject<T>(ref T obj) where T : IResettable
+        private void StoreObject<T>(ref T obj) where T : IResettable, new()
         {
             ResettableObjectCaches<T>.Store(obj);
             obj = default;

--- a/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/ObjectCaching.cs
+++ b/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/ObjectCaching.cs
@@ -24,7 +24,7 @@ namespace GameKit.Dependencies.Utilities
     /// <summary>
     /// Caches collections of multiple generics.
     /// </summary>
-    public static class ResettableCollectionCaches<T1, T2> where T1 : IResettable where T2 : IResettable
+    public static class ResettableCollectionCaches<T1, T2> where T1 : IResettable, new() where T2 : IResettable, new()
     {
         /// <summary>
         /// Retrieves a collection.
@@ -66,7 +66,7 @@ namespace GameKit.Dependencies.Utilities
     /// <summary>
     /// Caches collections of multiple generics.
     /// </summary>
-    public static class ResettableT1CollectionCaches<T1, T2> where T1 : IResettable
+    public static class ResettableT1CollectionCaches<T1, T2> where T1 : IResettable, new()
     {
         /// <summary>
         /// Retrieves a collection.
@@ -106,7 +106,7 @@ namespace GameKit.Dependencies.Utilities
     /// <summary>
     /// Caches collections of multiple generics.
     /// </summary>
-    public static class ResettableT2CollectionCaches<T1, T2> where T2 : IResettable
+    public static class ResettableT2CollectionCaches<T1, T2> where T2 : IResettable, new()
     {
         /// <summary>
         /// Retrieves a collection.
@@ -148,7 +148,7 @@ namespace GameKit.Dependencies.Utilities
     /// <summary>
     /// Caches collections of a single generic.
     /// </summary>
-    public static class ResettableCollectionCaches<T> where T : IResettable
+    public static class ResettableCollectionCaches<T> where T : IResettable, new()
     {
         /// <summary>
         /// Cache for ResettableRingBuffer.
@@ -296,7 +296,7 @@ namespace GameKit.Dependencies.Utilities
     /// <summary>
     /// Caches objects of a single generic.
     /// </summary>
-    public static class ResettableObjectCaches<T> where T : IResettable
+    public static class ResettableObjectCaches<T> where T : IResettable, new()
     {
         /// <summary>
         /// Retrieves an instance of T.
@@ -632,7 +632,7 @@ namespace GameKit.Dependencies.Utilities
     /// <summary>
     /// Caches objects of a single generic.
     /// </summary>
-    public static class ObjectCaches<T>
+    public static class ObjectCaches<T> where T : new()
     {
         /// <summary>
         /// Stack to use.
@@ -646,7 +646,7 @@ namespace GameKit.Dependencies.Utilities
         public static T Retrieve()
         {
             if (_stack.Count == 0)
-                return Activator.CreateInstance<T>();
+                return new T();
             else
                 return _stack.Pop();
         }


### PR DESCRIPTION
It's slower than new T() so add a generic constraint on that instead.

Everything internal to fish can be constrained this way.