### PR TITLE
Substream feature

### DIFF
--- a/Assets/FishNet/Runtime/Serializing/Reader.cs
+++ b/Assets/FishNet/Runtime/Serializing/Reader.cs
@@ -1472,6 +1472,24 @@ namespace FishNet.Serializing
                 return count;
             }
         }
+        /// <summary>
+        /// Reads a substream. Start reading from it with StartReading method.
+        /// </summary>
+        /// <returns>Returns SubStream</returns>
+        public SubStream ReadSubStream()
+        {
+            // read length of subStream
+            int streamLength = ReadInt32();
+
+            // if length is -1, it is invalid
+            if (streamLength == -1)
+            {
+                // returns Uninitialized SubStream
+                return SubStream.GetUninitialized();
+            }
+
+            return SubStream.CreateFromReader(this, streamLength);
+        }
 
         /// <summary>
         /// Reads any supported type.

--- a/Assets/FishNet/Runtime/Serializing/SubStream.cs
+++ b/Assets/FishNet/Runtime/Serializing/SubStream.cs
@@ -153,7 +153,6 @@ namespace FishNet.Serializing {
         /// <summary>
         /// Used internally to get writer of SubStream
         /// </summary>
-        /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
         internal PooledWriter GetWriter()
         {

--- a/Assets/FishNet/Runtime/Serializing/SubStream.cs
+++ b/Assets/FishNet/Runtime/Serializing/SubStream.cs
@@ -30,6 +30,10 @@ namespace FishNet.Serializing {
     ///     - might be unsafe to use this to send from clients (undefined data length), but so is sending T[] or List<T> from clients
     ///     - not to be used for IReplicateData/input structs, because underlying reading buffer may be changed where as IReplicateData structs are stored internally in replay buffer (substream buffer is not)
     /// 
+    /// Note:
+    ///     - If you write/read custom structs ONLY via SubStream, automatic serializer will not pick those up. Mark those custom structs with [FishNet.CodeGenerating.IncludeSerialization].
+    ///     Codegen detects only custom structs that are used in RPC/Broadcast methods, not in SubStream.
+    ///     
     /// </summary>
     public struct SubStream : IDisposable
     {

--- a/Assets/FishNet/Runtime/Serializing/SubStream.cs
+++ b/Assets/FishNet/Runtime/Serializing/SubStream.cs
@@ -1,0 +1,182 @@
+using FishNet.Serializing;
+using System;
+using FishNet.Managing;
+using System.Diagnostics;
+using FishNet.Documenting;
+
+namespace FishNet.Serializing {
+
+    /// <summary>
+    /// Special reader/writer buffer struct that can be used in Fishnet RPCs or Broadcasts.
+    ///
+    /// Use cases:
+    ///     - replacement for stream sort of
+    ///     - instead of always allocating some arrays T[] and sending that over RPCs, you can use SubStream
+    ///     - you can pass SubStream into objects via reference 'ref', and those objects write/read state, useful for dynamic length reconcile (items, inventory, buffs, etc...)
+    /// 
+    /// 
+    /// Pros:
+    ///     - reading is zero copy, reads directly from FishNet buffers
+    ///     - everything is pooled
+    ///     - ease of use
+    ///     - SubStream can also be uninitialized (default)
+    /// Cons:
+    ///     - writing is also pooled, but it's copied (since you write into it, then what is written is copied into fishnet stream, but it's byte copy (fast)
+    ///     - have to use Dispose() to return buffers to pool, or it may result in memory leak
+    ///     - can work safely only with Broadcasts that have only 1 receiver event
+    ///     - might be unsafe to use this to send from clients (undefined data length), but so is sending T[] or List<T> from clients
+    /// 
+    /// </summary>
+
+    
+    public struct SubStream : IDisposable
+    {
+        public bool Initialized { get; private set; }
+        public int Length { get => _writer != null ? _writer.Length : _reader != null ? _reader.Length : 1; }
+        public int Remaining { get => _reader != null ? _reader.Remaining : -1; }
+        public NetworkManager Manager { get => _writer != null ? _writer.NetworkManager : _reader != null ? _reader.NetworkManager: null; }
+
+        [NonSerialized]
+        private PooledReader _reader;
+        
+        [NonSerialized]
+        private int _startPosition;
+        
+        [NonSerialized] 
+        private PooledWriter _writer;
+
+        [NonSerialized]
+        private bool _disposed;
+        
+        /// <summary>
+        /// Creates SubStream for writing, use this before sending into RPC or Broadcast
+        /// </summary>
+        /// <param name="manager">Need to include network manager for handling of networked IDs</param>
+        /// <param name="minimumLength">Minimum expected length of data, that will be written</param>
+        /// <returns>Returns writer of SubStream</returns>
+        public static SubStream StartWriting(NetworkManager manager, out PooledWriter writer, int minimumLength = 0)
+        {
+            if (minimumLength == 0)
+            {
+                writer = WriterPool.Retrieve(manager);
+            }
+            else
+            {
+                writer = WriterPool.Retrieve(manager, minimumLength);
+            }
+
+            var stream = new SubStream()
+            {
+                _writer = writer,
+                Initialized = true,
+            };
+
+            return stream;
+        }
+
+        /// <summary>
+        /// Starts reading from substream via Reader class. Do not forget do Dispose() after reading
+        /// </summary>
+        /// <param name="reader">Reader to read data from</param>
+        /// <returns>Returns true, if SubStream is initialized else false</returns>
+        public bool StartReading(out Reader reader)
+        {
+            if(Initialized)
+            {
+                // reset reader, in case we are reading in multiple broadcasts delegates/events
+                _reader.Position = _startPosition;
+                reader = _reader;
+                return true;
+            }
+            reader = null;
+            return false;
+        }
+
+        public static SubStream CreateFromReader(Reader originalReader, int subStreamLength)
+        {
+            if(subStreamLength < 0)
+                throw new ArgumentException("SubStream length cannot be less than 0");
+            
+            var originalReaderBuffer = originalReader.GetByteBuffer();
+
+            // inherits reading buffer directly from fishnet reader
+            var arraySegment = new ArraySegment<byte>(originalReaderBuffer, originalReader.Position, subStreamLength);
+
+            var newReader = ReaderPool.Retrieve(arraySegment, originalReader.NetworkManager);
+
+            // advance original reader by length of substream data
+            originalReader.Skip(subStreamLength);
+
+            return new SubStream()
+            {
+                _startPosition = newReader.Position,
+                _reader = newReader,
+                _writer = null,
+                _disposed = false,
+                Initialized = true,
+            };
+        }
+
+        public PooledWriter GetWriter()
+        {
+            if (!Initialized)
+                throw new ArgumentException("SubStream was not initialized, it has to be initialized properly either localy or remotely!");
+
+            if (_writer == null)
+                throw new ArgumentException($"GetWriter() requires SubStream to be initialized as writer! You have to create SubStream with {nameof(StartWriting)}()!");
+
+            return _writer;
+        }
+
+        public PooledReader GetReader()
+        {
+            if (!Initialized)
+                throw new ArgumentException("SubStream was not initialized, it has to be initialized properly either localy or remotely!");
+
+            if (_reader == null)
+                throw new ArgumentException($"GetReader() requires SubStream to be initialized as reader!");
+
+            return _reader;
+        }
+
+        internal static SubStream GetUninitialized()
+        {
+            return new SubStream()
+            {
+                Initialized = false,
+            };
+        }
+
+        /// <summary>
+        /// Do not forget to call this after:
+        /// - you stopped writing to Substream AND already sent it via RPCs/Broadcasts
+        /// - you stoped reading from it inside RPCs/Broadcast receive event
+        /// </summary>
+        public void Dispose()
+        {
+            if (!_disposed) // dispose reader only once
+            {
+                _disposed = true;
+
+                if (_reader != null)
+                {
+                    _reader.Store();
+                    _reader = null;
+                }
+            }
+
+            if (_writer != null)
+            {
+                if (_writer.Length < WriterPool.LENGTH_BRACKET) // 1000 is LENGTH_BRACKET
+                    _writer.Store();
+                else
+                    _writer.StoreLength();
+                
+                _writer = null;
+            }
+        }
+
+    }
+
+}
+

--- a/Assets/FishNet/Runtime/Serializing/SubStream.cs.meta
+++ b/Assets/FishNet/Runtime/Serializing/SubStream.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 57d686fa997342244bec81094508639b

--- a/Assets/FishNet/Runtime/Serializing/Writer.cs
+++ b/Assets/FishNet/Runtime/Serializing/Writer.cs
@@ -1334,6 +1334,27 @@ namespace FishNet.Serializing
                 WriteArray<T>(value, 0, value.Length);
         }
 
+        /// <summary>
+        /// Writes an SubStream.
+        /// </summary>
+        /// <param name="value">Substream</param>
+        public void WriteSubStream(SubStream value)
+        {
+            // Uninitialized substream, write Length as -1
+            if (!value.Initialized)
+            {
+                WriteInt32(-1);
+            }
+            else
+            {
+                var bufferWriter = value.GetWriter();
+
+                // write length and data
+                WriteInt32(bufferWriter.Length);
+                WriteBytes(bufferWriter.GetBuffer(), 0, bufferWriter.Length);
+            }
+        }
+
 
         /// <summary>
         /// Writes any supported type.

--- a/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/LiteNetLib/LiteNetLib.csproj.meta
+++ b/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/LiteNetLib/LiteNetLib.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 1ec83424c5410b04aab06dddca60e7f6
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/FishNet/SubStreamTest.meta
+++ b/Assets/FishNet/SubStreamTest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87a40cf1c6fa3f74ebe57cb531cd3f50
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/SubStreamTest/SubStreamBroadcastTest.cs
+++ b/Assets/FishNet/SubStreamTest/SubStreamBroadcastTest.cs
@@ -1,0 +1,191 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using FishNet.Object;
+using FishNet.Serializing;
+using FishNet.Connection;
+using UnityEditor.MemoryProfiler;
+using UnityEngine.UIElements;
+using FishNet.Transporting;
+using FishNet.Broadcast;
+using static UnityEngine.Analytics.IAnalytic;
+using UnityEngine.Analytics;
+
+public class SubStreamBroadcastTest : NetworkBehaviour
+{
+    private struct BroadcastStruct : IBroadcast
+    {
+        public SubStream Stream;
+    }
+
+    private struct MegaBroadcastStruct : IBroadcast
+    {
+        public int Integer;
+        public float FP;
+        public string Text;
+
+        public SubStream StreamA;
+        public SubStream StreamB;
+    }
+
+    public override void OnStartServer()
+    {
+        base.OnStartServer();
+    }
+
+    private void FixedUpdate()
+    {
+        if (IsServerInitialized)
+        {
+            SendBroadcastStruct();
+            SendMegaBroadcastStruct();
+        }
+    
+    }
+
+    private void SendBroadcastStruct()
+    {
+        SubStream stream = SubStream.StartWriting(this.NetworkManager, out PooledWriter writer);
+
+        WriteRandomDataToBuffer(writer);
+
+        ServerManager.Broadcast<BroadcastStruct>(
+            new BroadcastStruct() { Stream = stream }
+        );
+
+        stream.Dispose();
+    }
+
+    private void SendMegaBroadcastStruct()
+    {
+        using (SubStream streamA = SubStream.StartWriting(this.NetworkManager, out PooledWriter writerA))
+        {
+            using (SubStream streamB = SubStream.StartWriting(this.NetworkManager, out PooledWriter writerB))
+            {
+                WriteRandomDataToBuffer(writerA);
+                WriteRandomDataToBuffer(writerB);
+
+                var data = new MegaBroadcastStruct()
+                {
+                    Integer = 100,
+                    FP = 420f,
+                    Text = "FISHNET",
+                    StreamA = streamA,
+                    StreamB = streamB
+                };
+
+                ServerManager.Broadcast<MegaBroadcastStruct>(data);
+            }
+        }
+    }
+
+    private void WriteRandomDataToBuffer(Writer writer)
+    {
+        int randomLength = Random.Range(1, 100);
+
+        writer.WriteInt32(randomLength);
+
+        for (int i = 0; i < randomLength; i++)
+        {
+            writer.WriteInt32(i*i);
+        }
+
+        writer.WriteInt32(100);
+        writer.WriteSingle(420f);
+        writer.WriteString("hello fishworld!");
+    }
+
+    private void VerifyRandomDataFromBuffer(Reader reader)
+    {
+        int randomLength = reader.ReadInt32();
+
+        for (int i = 0; i < randomLength; i++)
+        {
+            int value = reader.ReadInt32();
+
+            if (value != i*i)
+            {
+                Debug.LogError("Value is not equal to index");
+            }
+        }
+
+        if(reader.ReadInt32() != 100)
+        {
+            Debug.LogError("Integer is not equal to 100");
+        }
+
+        if(reader.ReadSingle() != 420f)
+        {
+            Debug.LogError("Float is not equal to 420f");
+        }
+
+        if(reader.ReadString() != "hello fishworld!")
+        {
+            Debug.LogError("String is not equal to hello fishworld!");
+        }
+    }
+
+    public override void OnStartClient()
+    {
+        base.OnStartClient();
+
+        ClientManager.RegisterBroadcast<BroadcastStruct>(ServerMessageReceivedA);
+        ClientManager.RegisterBroadcast<BroadcastStruct>(ServerMessageReceivedB);
+        ClientManager.RegisterBroadcast<MegaBroadcastStruct>(MegaBroadcastReceived);
+    }
+
+    private void ServerMessageReceivedA(BroadcastStruct data, Channel channel = Channel.Reliable)
+    {
+        ServerMessageReceivedParse(data.Stream);
+    }
+
+    private void ServerMessageReceivedB(BroadcastStruct data, Channel channel = Channel.Reliable)
+    {
+        ServerMessageReceivedParse(data.Stream);
+    }
+
+    private void ServerMessageReceivedParse(SubStream stream)
+    {
+        if (stream.StartReading(out Reader reader))
+        {
+            VerifyRandomDataFromBuffer(reader);
+        }
+    }
+
+    private void MegaBroadcastReceived(MegaBroadcastStruct data, Channel channel = Channel.Reliable)
+    {
+        Debug.Log("MegaBroadcastReceived");
+        // start reading StreamB on purpose before StreamA!
+        if (data.StreamB.StartReading(out Reader readerB))
+        {
+            VerifyRandomDataFromBuffer(readerB);
+        }
+
+        if (data.StreamA.StartReading(out Reader readerA))
+        {
+            VerifyRandomDataFromBuffer(readerA);
+        }
+
+        /*
+            Integer = 100,
+            FP = 420f,
+            Text = "Hello fishworld!",         
+        */
+
+        if (data.Integer != 100)
+        {
+            Debug.LogError("Integer is not equal to 100");
+        }
+
+        if (data.FP != 420f)
+        {
+            Debug.LogError("Float is not equal to 420f");
+        }
+
+        if (data.Text != "FISHNET")
+        {
+            Debug.LogError("String is not equal to FISHNET");
+        }
+
+    }
+}

--- a/Assets/FishNet/SubStreamTest/SubStreamBroadcastTest.cs.meta
+++ b/Assets/FishNet/SubStreamTest/SubStreamBroadcastTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60f9b98e3ca7fe241b7d54366f4869f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/SubStreamTest/SubStreamExample.cs
+++ b/Assets/FishNet/SubStreamTest/SubStreamExample.cs
@@ -9,6 +9,7 @@ using UnityEngine.UIElements;
 
 public class SubStreamExample : NetworkBehaviour
 {
+    // this method calls RPC
     public void SendData()
     {
         var stream = SubStream.StartWriting(NetworkManager, out PooledWriter paramWriter);
@@ -19,6 +20,7 @@ public class SubStreamExample : NetworkBehaviour
 
         TestObserverRPC(1, stream, Vector3.zero);
         
+        // must always be disposed after sending RPC
         stream.Dispose();
     }
 
@@ -30,8 +32,14 @@ public class SubStreamExample : NetworkBehaviour
             var text = reader.ReadString();
             var number = reader.ReadInt32();
 
+            // must always be disposed after reading
             stream.Dispose();
         }
     }
 
+    struct PathfindingData
+    {
+        public Vector3 StartPosition;
+        public SubStream PathDeltasStream;
+    }
 }

--- a/Assets/FishNet/SubStreamTest/SubStreamExample.cs
+++ b/Assets/FishNet/SubStreamTest/SubStreamExample.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using FishNet.Object;
+using FishNet.Serializing;
+using FishNet.Connection;
+using UnityEditor.MemoryProfiler;
+using UnityEngine.UIElements;
+
+public class SubStreamExample : NetworkBehaviour
+{
+    public void SendData()
+    {
+        var stream = SubStream.StartWriting(NetworkManager, out PooledWriter paramWriter);
+        
+        // write anything to the stream
+        paramWriter.Write("Hello fishes!");
+        paramWriter.WriteInt32(128);
+
+        TestObserverRPC(1, stream, Vector3.zero);
+        
+        stream.Dispose();
+    }
+
+    [ObserversRpc]
+    void TestObserverRPC(int randomParam, SubStream stream, Vector3 randomVec) {
+
+        if(stream.StartReading(out Reader reader)) {
+            // read the data from the stream in same order
+            var text = reader.ReadString();
+            var number = reader.ReadInt32();
+
+            stream.Dispose();
+        }
+    }
+
+}

--- a/Assets/FishNet/SubStreamTest/SubStreamExample.cs.meta
+++ b/Assets/FishNet/SubStreamTest/SubStreamExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b51916ea4d1564f4697dc5a1c1de1755
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/SubStreamTest/SubStreamRPCTest.cs
+++ b/Assets/FishNet/SubStreamTest/SubStreamRPCTest.cs
@@ -1,0 +1,269 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using FishNet.Object;
+using FishNet.Serializing;
+using FishNet.Connection;
+using UnityEditor.MemoryProfiler;
+using UnityEngine.UIElements;
+
+public class SubStreamRPCTest : NetworkBehaviour
+{
+    public override void OnSpawnServer(NetworkConnection conn) {
+        base.OnSpawnServer(conn);
+
+        TestWritingToSubStream(conn);
+    }
+
+    public override void OnStartClient() {
+        base.OnStartClient();
+
+        using (SubStream subStream = SubStream.StartWriting(NetworkManager, out PooledWriter writer)) {
+
+            writer.Write("Hello world from client!");
+            writer.Write("I am calling ServerRPC!");
+            writer.Write("Stuff!");
+
+            TestServerRPC(subStream);
+
+            //ShouldFailTestServerRPC(subStream);
+        }
+    }
+
+    public void TestWritingToSubStream(NetworkConnection conn) {
+
+        #region TargetRPC Test
+        SubStream streamA = SubStream.StartWriting(this.NetworkManager, out PooledWriter writerA);
+        SubStream streamB = SubStream.StartWriting(this.NetworkManager, out PooledWriter writerB);
+
+        writerA.Write("StreamA");
+        writerB.Write("StreamB");
+
+        TestTargetRPC(conn, streamA, streamB);
+        TestTargetRPC(conn, default, streamB);
+        TestTargetRPC(conn, streamA, default);
+        TestTargetRPC(conn, default, default);
+
+        streamA.Dispose();
+        streamB.Dispose();
+        #endregion
+
+        #region Struct Test
+        TestStruct testStr = new TestStruct() {
+            Pos = Vector3.one,
+            Vel = Vector3.one
+        };
+
+        using (SubStream structStream = SubStream.StartWriting(this.NetworkManager, out PooledWriter writerStruct)) {
+
+            writerStruct.Write("StructStream");
+
+            testStr.Stream = structStream;
+
+            TestStructObserverRPC(testStr);
+        }
+        #endregion
+
+        #region Mixed Parameters Test
+
+        using (SubStream mixedStream = SubStream.StartWriting(NetworkManager, out PooledWriter writer)) {
+
+            writer.Write(10);
+            writer.Write("String inside stream sent over RPC!");
+            writer.Write(10);
+            writer.Write(Vector3.one);
+
+            MixedParametersObserverRPC(Vector3.one, mixedStream, "SimpleString", 3.14f);
+        }
+
+        #endregion
+    }
+
+
+    [TargetRpc]
+    public void TestTargetRPC(NetworkConnection conn, SubStream streamA, SubStream streamB) {
+
+        Debug.Log("[TestTargetRPC]");
+
+        if(streamA.StartReading(out Reader readerA)) {
+
+            if(readerA.ReadString() != "StreamA") {
+                Debug.LogError("StreamA string does not match!");
+            }
+
+            streamA.Dispose();
+        }
+
+        if(streamB.StartReading(out Reader readerB)) {
+
+            if(readerB.ReadString() != "StreamB") {
+                Debug.LogError("StreamB string does not match!");
+            }
+
+            streamB.Dispose();
+        }        
+    }
+
+    public struct TestStruct {
+        public Vector3 Pos;
+        public SubStream Stream;
+        public Vector3 Vel;
+    }
+    
+    [ObserversRpc]
+    public void TestStructObserverRPC(TestStruct testStruct) {
+
+        Debug.Log("[TestObserverRPC]");
+
+        if(testStruct.Pos != Vector3.one) {
+            Debug.LogError("Position does not match!");
+        }
+
+        if(testStruct.Vel != Vector3.one) {
+            Debug.LogError("Velocity does not match!");
+        }
+
+        if (testStruct.Stream.StartReading(out Reader reader)) {
+
+            if(reader.ReadString() != "StructStream") {
+                Debug.LogError("String does not match!");
+            }
+        }
+    }
+
+    [ObserversRpc]
+    public void MixedParametersObserverRPC(Vector3 pos, SubStream dataStream, string text, float number) {
+
+        Debug.Log("[MixedParametersObserverRPC]");
+
+        if(pos != Vector3.one) {
+            Debug.LogError("pos does not match!");
+        }
+
+        if(text != "SimpleString") {
+            Debug.LogError("text does not match!");
+        }
+
+        if(number != 3.14f) {
+            Debug.LogError("number does not match!");
+        }
+
+        if(dataStream.StartReading(out Reader reader)) {
+
+            if(reader.ReadInt32() != 10) {
+                Debug.LogError("Int does not match!");
+            }
+
+            if(reader.ReadString() != "String inside stream sent over RPC!") {
+                Debug.LogError("String does not match!");
+            }
+
+            if(reader.ReadInt32() != 10) {
+                Debug.LogError("Int does not match!");
+            }
+
+            if(reader.ReadVector3() != Vector3.one) {
+                Debug.LogError("Vector3 does not match!");
+            }
+
+            dataStream.Dispose();
+        }
+
+    }
+    
+    void FixedUpdate()
+    {       
+        using(SubStream stream = SubStream.StartWriting(NetworkManager, out PooledWriter writer)) {
+
+            writer.Write("Hello world");
+
+            int length = UnityEngine.Random.Range(5, 15);
+
+            int hash = length.GetHashCode();
+
+            writer.WriteInt16((short)length);
+            for(int i = 0; i < length; i++) {
+
+                var randomInt = UnityEngine.Random.Range(-100, 100);
+                writer.WriteInt32(randomInt);
+                hash ^= randomInt.GetHashCode();
+            }
+
+            writer.WriteInt32(hash);
+
+            FixedUpdateObserverRPC(Time.timeSinceLevelLoad, stream);
+        }
+    }
+
+    [ObserversRpc]
+    void FixedUpdateObserverRPC(float time, SubStream data) {
+
+        //Debug.Log("[FixedUpdateObserverRPC]");
+
+        if(data.StartReading(out Reader reader)) {
+
+            var str = reader.ReadString();
+
+            int length = reader.ReadInt16();
+            
+            int calculatedHash = length.GetHashCode();
+
+            for(int i = 0; i < length; i++) {
+                var randomInt = reader.ReadInt32();
+                calculatedHash ^= randomInt.GetHashCode();
+            }
+
+            var sentHash = reader.ReadInt32();
+
+            if(sentHash != calculatedHash) {
+                Debug.LogError("Hashes do not match!");
+            }
+
+            data.Dispose();
+        }
+    }
+
+
+    [ServerRpc(RequireOwnership = false)]
+    void TestServerRPC(SubStream stream, NetworkConnection conn = null) {
+
+        Debug.Log("[TestServerRPC]");
+
+        if(stream.StartReading(out Reader reader)) {
+
+
+            if(reader.ReadString() != "Hello world from client!") {
+                Debug.LogError("String does not match!");
+            }
+
+            if(reader.ReadString() != "I am calling ServerRPC!") {
+                Debug.LogError("String does not match!");
+            }
+
+            if(reader.ReadString() != "Stuff!") {
+                Debug.LogError("String does not match!");
+            }
+
+            stream.Dispose();
+        }
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    void ShouldFailTestServerRPC(SubStream stream, NetworkConnection conn = null) {
+
+        Debug.Log("[ShouldFailTestServerRPC]");
+
+        if(stream.StartReading(out Reader reader)) {
+
+            reader.ReadString();
+            reader.ReadString();
+            reader.ReadString();
+
+            //fails here, note that not all Reader methods have reading protection
+            reader.ReadString();
+
+            stream.Dispose();
+        }
+    }
+
+}

--- a/Assets/FishNet/SubStreamTest/SubStreamRPCTest.cs.meta
+++ b/Assets/FishNet/SubStreamTest/SubStreamRPCTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b39e8c2dddb1a245888eec09c38e434
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FishNet/SubStreamTest/SubStreamScene.unity
+++ b/Assets/FishNet/SubStreamTest/SubStreamScene.unity
@@ -1,0 +1,866 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &615342847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 615342850}
+  - component: {fileID: 615342849}
+  - component: {fileID: 615342848}
+  - component: {fileID: 615342851}
+  m_Layer: 0
+  m_Name: SubStreamGO
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &615342848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b39e8c2dddb1a245888eec09c38e434, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 0
+  _addedNetworkObject: {fileID: 615342849}
+  _networkObjectCache: {fileID: 615342849}
+--- !u!114 &615342849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <IsNested>k__BackingField: 0
+  <ComponentIndex>k__BackingField: 0
+  <PredictedSpawn>k__BackingField: {fileID: 0}
+  _networkBehaviours:
+  - {fileID: 615342848}
+  - {fileID: 615342851}
+  <SerializedRootNetworkBehaviour>k__BackingField: {fileID: 0}
+  <NestedRootNetworkBehaviours>k__BackingField: []
+  SerializedTransformProperties:
+    Position: {x: 0, y: 0, z: 0}
+    Rotation: {x: 0, y: 0, z: 0, w: 1}
+    LocalScale: {x: 1, y: 1, z: 1}
+  _isNetworked: 1
+  _isSpawnable: 1
+  _isGlobal: 0
+  _initializeOrder: 0
+  _defaultDespawnType: 0
+  NetworkObserver: {fileID: 0}
+  _enablePrediction: 0
+  _predictionType: 0
+  _graphicalObject: {fileID: 0}
+  _detachGraphicalObject: 0
+  _enableStateForwarding: 1
+  _networkTransform: {fileID: 0}
+  _ownerInterpolation: 1
+  _ownerSmoothedProperties: 255
+  _adaptiveInterpolation: 3
+  _spectatorSmoothedProperties: 255
+  _spectatorInterpolation: 2
+  _enableTeleport: 0
+  _teleportThreshold: 1
+  <PrefabId>k__BackingField: 0
+  <SpawnableCollectionId>k__BackingField: 0
+  _scenePathHash: 3291160933
+  <SceneId>k__BackingField: 14135428574804092725
+  <AssetPathHash>k__BackingField: 0
+--- !u!4 &615342850
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &615342851
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615342847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60f9b98e3ca7fe241b7d54366f4869f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 1
+  _addedNetworkObject: {fileID: 615342849}
+  _networkObjectCache: {fileID: 615342849}
+--- !u!114 &31255994101980119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8492223723419120170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.25490198, g: 0.25490198, b: 0.25490198, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b3dca501a9d8c8479dc71dd068aa8b8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!223 &833561939391683936
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &833561939391683937
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 833561939412960708}
+  - {fileID: 833561939932868676}
+  m_Father: {fileID: 5776661931769733468}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &833561939391683938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &833561939391683939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!1 &833561939391683964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 833561939391683937}
+  - component: {fileID: 833561939391683965}
+  - component: {fileID: 833561939391683936}
+  - component: {fileID: 833561939391683939}
+  - component: {fileID: 833561939391683938}
+  m_Layer: 5
+  m_Name: NetworkHudCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &833561939391683965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939391683964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d3606bfdac5a4743890fc1a5ecd8f24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _autoStartType: 1
+  _stoppedColor: {r: 0.25490198, g: 0.25490198, b: 0.25490198, a: 1}
+  _changingColor: {r: 0.78431374, g: 0.6862745, b: 0, a: 1}
+  _startedColor: {r: 0, g: 0.5882353, b: 0.64705884, a: 1}
+  _serverIndicator: {fileID: 31255994101980119}
+  _clientIndicator: {fileID: 2640692993215481821}
+--- !u!224 &833561939412960708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5982800601722334148}
+  m_Father: {fileID: 833561939391683937}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 16, y: -16}
+  m_SizeDelta: {x: 256, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &833561939412960709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 833561939412960714}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 833561939391683965}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: OnClick_Server
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &833561939412960711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 833561939412960708}
+  - component: {fileID: 833561939412960715}
+  - component: {fileID: 833561939412960714}
+  - component: {fileID: 833561939412960709}
+  m_Layer: 5
+  m_Name: Server
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &833561939412960714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1b187e63031bf7849b249c8212440c3b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &833561939412960715
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939412960711}
+  m_CullTransparentMesh: 0
+--- !u!224 &833561939932868676
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5310255346163286054}
+  m_Father: {fileID: 833561939391683937}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 16, y: -96}
+  m_SizeDelta: {x: 256, y: 64}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &833561939932868677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 833561939932868682}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 833561939391683965}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: OnClick_Client
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &833561939932868679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 833561939932868676}
+  - component: {fileID: 833561939932868683}
+  - component: {fileID: 833561939932868682}
+  - component: {fileID: 833561939932868677}
+  m_Layer: 5
+  m_Name: Client
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &833561939932868682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2d50394614f8feb4eb0567fb7618d84d, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &833561939932868683
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833561939932868679}
+  m_CullTransparentMesh: 0
+--- !u!1 &1516907665569361716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5310255346163286054}
+  - component: {fileID: 7708060694241303342}
+  - component: {fileID: 2640692993215481821}
+  m_Layer: 5
+  m_Name: Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2640692993215481821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516907665569361716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.25490198, g: 0.25490198, b: 0.25490198, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b3dca501a9d8c8479dc71dd068aa8b8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &5310255346163286054
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516907665569361716}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 833561939932868676}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!4 &5776661931769733468
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 833561939391683937}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5776661931769733470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5776661931769733468}
+  - component: {fileID: 5776661931769733471}
+  - component: {fileID: 5776661931769733472}
+  - component: {fileID: 5776661931769733473}
+  m_Layer: 0
+  m_Name: NetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &5776661931769733471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c95dfde7d73b54dbbdc23155d35d36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _refreshDefaultPrefabs: 0
+  _runInBackground: 1
+  _dontDestroyOnLoad: 1
+  _objectPool: {fileID: 0}
+  _persistence: 0
+  _logging: {fileID: 0}
+  _spawnablePrefabs: {fileID: 11400000, guid: 3a72037bac3462143a80cbc39336c3e9, type: 2}
+--- !u!114 &5776661931769733472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e08bb003fce297d4086cf8cba5aa459a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _dropExcessiveReplicates: 1
+  _maximumServerReplicates: 15
+  _stateInterpolation: 2
+--- !u!114 &5776661931769733473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5776661931769733470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f48f002b825cbd45a19bd96d90f9edb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _dontRoute: 0
+  _unreliableMtu: 1023
+  _ipv4BindAddress: 
+  _enableIpv6: 1
+  _ipv6BindAddress: 
+  _port: 7770
+  _maximumClients: 4095
+  _clientAddress: localhost
+--- !u!224 &5982800601722334148
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8492223723419120170}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 833561939412960708}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7708060694241303342
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516907665569361716}
+  m_CullTransparentMesh: 0
+--- !u!222 &8192313925857261485
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8492223723419120170}
+  m_CullTransparentMesh: 0
+--- !u!1 &8492223723419120170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5982800601722334148}
+  - component: {fileID: 8192313925857261485}
+  - component: {fileID: 31255994101980119}
+  m_Layer: 5
+  m_Name: Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 5776661931769733468}
+  - {fileID: 615342850}

--- a/Assets/FishNet/SubStreamTest/SubStreamScene.unity.meta
+++ b/Assets/FishNet/SubStreamTest/SubStreamScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 47437d4bba130b049b515708a08f6f2f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds SubStream struct that enables simplified serializing inside RPC functions or Broadcasts. It is GC free, albeit for writes there is one byte-buffer copy, read has zero copy.

It is an alternative to using byte[] or ArraySegment<byte> as a means for sending dynamically sized data.

Example:

    // this method calls RPC
    public void SendData()
    {
        var stream = SubStream.StartWriting(NetworkManager, out PooledWriter paramWriter);
        
        // write anything to the stream
        paramWriter.Write("Hello FishNet!");
        paramWriter.WriteInt32(128);

        TestObserverRPC(1, stream, Vector3.zero);
        
        stream.Dispose();
    }

    [ObserversRpc]
    void TestObserverRPC(int randomParam, SubStream stream, Vector3 randomVec) {

        if(stream.StartReading(out Reader reader)) {
            // read the data from the stream in same order
            var text = reader.ReadString();
            var number = reader.ReadInt32();

            stream.Dispose();
        }
    }

It also can be used inside structs, like this:

    struct PathfindingData
    {
        public Vector3 StartPosition;
        public SubStream PathDeltaStream;
    }


