### PR TITLE
Correctly mark value as set after initialized

### DIFF
--- a/Assets/FishNet/Runtime/Object/Synchronizing/SyncVar.cs
+++ b/Assets/FishNet/Runtime/Object/Synchronizing/SyncVar.cs
@@ -148,6 +148,9 @@ namespace FishNet.Object.Synchronizing
             if (updateClient)
                 _previousClientValue = next;
             _value = next;
+
+            if (base.IsInitialized)
+                _valueSetAfterInitialized = true;
         }
         /// <summary>
         /// Sets current value and marks the SyncVar dirty when able to. Returns if able to set value.


### PR DESCRIPTION
OnStartServer() says

    SyncTypes modified before or during this method will be sent to clients in the spawn message.

This is not true unless _valueSetAfterInitialized is correctly set when values are updated.
