### PR TITLE
Bugfix: Prevent null SyncDictionaries when field initializers get ignored.

### DIFF
--- a/Assets/FishNet/Runtime/Object/Synchronizing/SyncDictionary.cs
+++ b/Assets/FishNet/Runtime/Object/Synchronizing/SyncDictionary.cs
@@ -171,6 +171,13 @@ namespace FishNet.Object.Synchronizing
         protected override void Initialized()
         {
             base.Initialized();
+
+            // Ensure that initialized values always get set
+            _initialValues ??= new Dictionary<TKey, TValue>();
+            _changed ??= new List<ChangeData>();
+            _serverOnChanges ??= new List<CachedOnChange>();
+            _clientOnChanges ??= new List<CachedOnChange>();
+
             foreach (KeyValuePair<TKey, TValue> item in Collection)
                 _initialValues[item.Key] = item.Value;
         }


### PR DESCRIPTION
Certain serializers like Sirenix's Odin will cause the field initializers to get ignored, and so we should check for that in the `Initialized` function and set them if they are null.

This is in reference to issue #693 