### PR TITLE
Fix RingBuffer Capacity

### DIFF
--- a/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/Types/ResettableRingBuffer.cs
+++ b/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/Types/ResettableRingBuffer.cs
@@ -210,7 +210,7 @@ namespace GameKit.Dependencies.Utilities.Types
                 GetNewCollection();
             }
 
-            Capacity = capacity;
+            Capacity = Collection.Length;
             Initialized = true;
 
             void GetNewCollection() => Collection = ArrayPool<T>.Shared.Rent(capacity);

--- a/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/Types/RingBuffer.cs
+++ b/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/Types/RingBuffer.cs
@@ -617,7 +617,7 @@ namespace GameKit.Dependencies.Utilities.Types
                 GetNewCollection();
             }
 
-            Capacity = capacity;
+            Capacity = Collection.Length;
             Initialized = true;
 
             void GetNewCollection() => Collection = ArrayPool<T>.Shared.Rent(capacity);


### PR DESCRIPTION
ArrayPool<T>.Shared.Rent can return variable length arrays which may be slightly larger than the specified capacity due to more efficient memory block sizes. We may as well take advantage of that extra memory.

Example: A capacity of 15 will generally return an array of size 16 instead.