### PR TITLE
Fix NetworkTransform SetSynchronizedProperties method

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
@@ -2328,7 +2328,7 @@ namespace FishNet.Component.Transforming
         /// <summary>
         /// Sets synchronized values based on value.
         /// </summary>
-        [ServerRpc]
+        [ServerRpc(RequireOwnership = true)]
         private void ServerSetSynchronizedProperties(SynchronizedProperty value)
         {
             if (!_clientAuthoritative)
@@ -2337,20 +2337,15 @@ namespace FishNet.Component.Transforming
                 return;
             }
 
-            SetSynchronizedPropertiesInternal(value);
             ObserversSetSynchronizedProperties(value);
         }
 
         /// <summary>
         /// Sets synchronized values based on value.
         /// </summary>
-        [ObserversRpc(BufferLast = true)]
+        [ObserversRpc(BufferLast = true, RunLocally = true)]
         private void ObserversSetSynchronizedProperties(SynchronizedProperty value)
         {
-            //Would have already run on server if host.
-            if (base.IsServerInitialized)
-                return;
-
             SetSynchronizedPropertiesInternal(value);
         }
 


### PR DESCRIPTION
* Change the NetworkTransform's SetSynchronizedProperties method to update the properties on both server and observers

* Add Ownership requirement to ServerSetSynchronizedProperties RPC for client authoritative Network Transforms

This makes the SetSynchronizedProperties method updates the NetworkTransform's synchronized properties for both server and observers.

Before, when called by Server it would only update for the Observers but not the Server itself.