### PR TITLE
Fix broken equality comparison check

### DIFF
--- a/Assets/FishNet/Runtime/Object/Synchronizing/Beta/SyncList.cs
+++ b/Assets/FishNet/Runtime/Object/Synchronizing/Beta/SyncList.cs
@@ -712,7 +712,7 @@ namespace FishNet.Object.Synchronizing
             if (!base.CanNetworkSetValues(true))
                 return;
 
-            bool sameValue = (!force && !_comparer.Equals(Collection[index], value));
+            bool sameValue = (!force && _comparer.Equals(Collection[index], value));
             if (!sameValue)
             {
                 T prev = Collection[index];

--- a/Assets/FishNet/Runtime/Object/Synchronizing/SyncList.cs
+++ b/Assets/FishNet/Runtime/Object/Synchronizing/SyncList.cs
@@ -745,7 +745,7 @@ namespace FishNet.Object.Synchronizing
             if (!base.CanNetworkSetValues(true))
                 return;
 
-            bool sameValue = (!force && !_comparer.Equals(Collection[index], value));
+            bool sameValue = (!force && _comparer.Equals(Collection[index], value));
             if (!sameValue)
             {
                 T prev = Collection[index];


### PR DESCRIPTION
Force is used in most places so this wasn't showing up but if it was false we would only dirty the index if the object being set was equal to the previous.