### PR TITLE
Rebuild selected scene sceneIds menu item

### DIFF
--- a/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
+++ b/Assets/FishNet/Runtime/Editor/Configuring/ConfigurationEditor.cs
@@ -103,6 +103,23 @@ namespace FishNet.Editing
 
     }
 
+    public class RebuildSelectedSceneIdsMenu : MonoBehaviour {
+        /// <summary>
+        /// Rebuilds sceneIds for open scenes.
+        /// </summary>
+        [MenuItem("Tools/Fish-Networking/Rebuild Selected Scenes's SceneIds", false, 20)]
+        public static void RebuildSelectedScenesSceneIds()
+        {
+            SceneAsset[] selectedScenes = Selection.GetFiltered<SceneAsset>(SelectionMode.Assets);
+            // Debug.Log(selectedScenes.Length);
+            for (int i = 0; i < selectedScenes.Length; ++i) {
+                string path = AssetDatabase.GetAssetPath(selectedScenes[i]);
+                Scene scene = EditorSceneManager.OpenScene(path, OpenSceneMode.Single);
+                RebuildSceneIdMenu.RebuildSceneIds();
+                EditorSceneManager.SaveScene(scene);
+            }
+        }
+    }
 
     public class RebuildSceneIdMenu : MonoBehaviour
     {


### PR DESCRIPTION
I am working a game that has a ton of scenes (It's open world and on a grid), so for me it's very inconvenient to load all my scenes one by one to rebuild the scene Ids if needed. That's why I made a small utility that allows the user to select many scenes, and it opens them automatically one by one, refreshes all Ids and saves them. I believe other FishNet users might find this useful to quickly make sure all their scenes are in order.