### PR TITLE
Add null check in animator

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs
@@ -365,7 +365,7 @@ namespace FishNet.Component.Animating
         {
             get
             {
-                bool enabled = (_animator.enabled || _synchronizeWhenDisabled);
+                bool enabled = _animator && (_animator.enabled || _synchronizeWhenDisabled);
                 bool failedChecks = (!_isAnimatorSet || !enabled);
                 return !failedChecks;
             }


### PR DESCRIPTION

`_isAnimatorSet` has null check.

https://github.com/FirstGearGames/FishNet/blob/f8cdf25b9dc2f92fc1aea9d48bcd85e26070a5a9/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs#L376-L381

`_canSynchronizeAnimator` doesn't have null check.

https://github.com/FirstGearGames/FishNet/blob/f8cdf25b9dc2f92fc1aea9d48bcd85e26070a5a9/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs#L364-L370

And periodically we have an error on server side.

```
MissingReferenceException: The object of type 'Animator' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
FishNet.Component.Animating.NetworkAnimator.get__canSynchronizeAnimator () (at Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs:368)
FishNet.Component.Animating.NetworkAnimator.TimeManager_OnPreTick () (at Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs:556)
FishNet.Managing.Timing.TimeManager.IncreaseTick () (at Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs:700)
FishNet.Managing.Timing.TimeManager.<TickUpdate>g__MethodLogic|100_0 () (at Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs:376)
FishNet.Managing.Timing.TimeManager.TickUpdate () (at Assets/FishNet/Runtime/Managing/Timing/TimeManager.cs:366)
FishNet.Transporting.NetworkReaderLoop.Update () (at Assets/FishNet/Runtime/Transporting/NetworkReaderLoop.cs:28)
```