### PR TITLE
Fix SyncTimer update time on clients

### DIFF
--- a/Assets/FishNet/Runtime/Object/Synchronizing/Beta/SyncTimer.cs
+++ b/Assets/FishNet/Runtime/Object/Synchronizing/Beta/SyncTimer.cs
@@ -291,6 +291,8 @@ namespace FishNet.Object.Synchronizing
                         Paused = false;
                         Remaining = next;
                         Duration = duration;
+
+                        SetUpdateTime();
                     }
 
                     if (newChangeId)
@@ -354,6 +356,12 @@ namespace FishNet.Object.Synchronizing
                 }
 
                 Paused = newPauseState;
+
+                if (!Paused && Remaining > 0f)
+                {
+                    SetUpdateTime();
+                }
+
                 if (newChangeId)
                     InvokeOnChange(op, prev, next, asServer);
             }


### PR DESCRIPTION
Set SyncTimer update time on clients to match how the server processes timers during start and unpause. Fixes SyncTimers on clients finishing immediately (https://github.com/FirstGearGames/FishNet/issues/807).