### PR TITLE
Fix Scene Load Caching

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
@@ -63,13 +63,15 @@ namespace FishNet.Managing.Scened
         /// Begin loading a scene using an async method.
         /// </summary>
         /// <param name="sceneName">Scene name to load.</param>
-        public override void BeginLoadAsync(string sceneName, UnityEngine.SceneManagement.LoadSceneParameters parameters)
+        public override void BeginLoadAsync(string sceneName, UnityEngine.SceneManagement.LoadSceneParameters parameters, Action<string> onSceneLoaded)
         {
             AsyncOperation ao = UnitySceneManager.LoadSceneAsync(sceneName, parameters);
             LoadingAsyncOperations.Add(ao);
             
             CurrentAsyncOperation = ao;
             CurrentAsyncOperation.allowSceneActivation = false;
+
+			ao.completed += (asyncOp) => onSceneLoaded?.Invoke(sceneName);
         }
 
         /// <summary>

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -3551,7 +3551,12 @@ namespace FishNet.Managing.Scened
                      * 1f / 2f is 0.5f. */
                     float maximumIndexWorth = (1f / (float)loadableScenes.Count);
 
-                    _sceneProcessor.BeginLoadAsync(loadableScenes[i].Name, loadSceneParameters);
+                    _sceneProcessor.BeginLoadAsync(loadableScenes[i].Name, loadSceneParameters, (s) =>
+					{
+						Scene loaded = UnitySceneManager.GetSceneByName(s);
+						loadedScenes.Add(loaded);
+						_sceneProcessor.AddLoadedScene(loaded);
+					});
                     while (!_sceneProcessor.IsPercentComplete())
                     {
                         float percent = _sceneProcessor.GetPercentComplete();
@@ -3573,9 +3578,9 @@ namespace FishNet.Managing.Scened
                     }
 
                     //Add to loaded scenes.
-                    Scene loaded = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1);
-                    loadedScenes.Add(loaded);
-                    _sceneProcessor.AddLoadedScene(loaded);
+                    //Scene loaded = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1);
+                    //loadedScenes.Add(loaded);
+                    //_sceneProcessor.AddLoadedScene(loaded);
                 }
                 //When all scenes are loaded invoke with 100% done.
                 InvokeOnScenePercentChange(data, 1f);

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneProcessorBase.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneProcessorBase.cs
@@ -66,7 +66,8 @@ namespace FishNet.Managing.Scened
         /// Begin loading a scene using an async method.
         /// </summary>
         /// <param name="sceneName">Scene name to load.</param>
-        public abstract void BeginLoadAsync(string sceneName, LoadSceneParameters parameters);
+		/// <param name="onSceneLoaded">Callback for when scene load is completed.</param>
+        public abstract void BeginLoadAsync(string sceneName, LoadSceneParameters parameters, Action<string> onSceneLoaded);
         /// <summary>
         /// Begin unloading a scene using an async method.
         /// </summary>


### PR DESCRIPTION
SceneProcessor will now accurately add the loaded scene to the loadedScenes and SceneProcessor.Scenes caches.
Before UnitySceneManager.GetSceneAt would access the last loaded scene. This creates an issue if the last scene loaded is loaded outside of the FishNet SceneManager.

Issue could also probably be fixed by simply changing line 3576 from:

Scene loaded = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1);

to 

Scene loaded = UnitySceneManager.GetSceneByName(loadableScenes[i].Name);