### PR TITLE
Fix Scene Load Caching

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
@@ -63,13 +63,20 @@ namespace FishNet.Managing.Scened
         /// Begin loading a scene using an async method.
         /// </summary>
         /// <param name="sceneName">Scene name to load.</param>
-        public override void BeginLoadAsync(string sceneName, UnityEngine.SceneManagement.LoadSceneParameters parameters)
+        public override void BeginLoadAsync(string sceneName, UnityEngine.SceneManagement.LoadSceneParameters parameters, Action<UnityScene> onLoadComplete)
         {
             AsyncOperation ao = UnitySceneManager.LoadSceneAsync(sceneName, parameters);
+
+            // This immediately returns the new scene handle regardless of being loaded or not.
+            UnityScene scene = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1);
+
             LoadingAsyncOperations.Add(ao);
             
             CurrentAsyncOperation = ao;
             CurrentAsyncOperation.allowSceneActivation = false;
+
+            // Capture scene handle in the lambda.
+            ao.completed += (s) => onLoadComplete?.Invoke(scene);
         }
 
         /// <summary>

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -3573,7 +3573,7 @@ namespace FishNet.Managing.Scened
                     }
 
                     //Add to loaded scenes.
-                    Scene loaded = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1);
+                    Scene loaded = UnitySceneManager.GetSceneByName(loadableScenes[i].Name);
                     loadedScenes.Add(loaded);
                     _sceneProcessor.AddLoadedScene(loaded);
                 }

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -3551,7 +3551,11 @@ namespace FishNet.Managing.Scened
                      * 1f / 2f is 0.5f. */
                     float maximumIndexWorth = (1f / (float)loadableScenes.Count);
 
-                    _sceneProcessor.BeginLoadAsync(loadableScenes[i].Name, loadSceneParameters);
+                    _sceneProcessor.BeginLoadAsync(loadableScenes[i].Name, loadSceneParameters, (loadedScene) =>
+                    {
+                        loadedScenes.Add(loadedScene);
+                        _sceneProcessor.AddLoadedScene(loadedScene);
+                    });
                     while (!_sceneProcessor.IsPercentComplete())
                     {
                         float percent = _sceneProcessor.GetPercentComplete();
@@ -3571,11 +3575,6 @@ namespace FishNet.Managing.Scened
                         //Dispatch with total percent.
                         InvokeOnScenePercentChange(data, totalPercent);
                     }
-
-                    //Add to loaded scenes.
-                    Scene loaded = UnitySceneManager.GetSceneByName(loadableScenes[i].Name);
-                    loadedScenes.Add(loaded);
-                    _sceneProcessor.AddLoadedScene(loaded);
                 }
                 //When all scenes are loaded invoke with 100% done.
                 InvokeOnScenePercentChange(data, 1f);

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneProcessorBase.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneProcessorBase.cs
@@ -66,7 +66,7 @@ namespace FishNet.Managing.Scened
         /// Begin loading a scene using an async method.
         /// </summary>
         /// <param name="sceneName">Scene name to load.</param>
-        public abstract void BeginLoadAsync(string sceneName, LoadSceneParameters parameters);
+        public abstract void BeginLoadAsync(string sceneName, LoadSceneParameters parameters, Action<Scene> onLoadComplete);
         /// <summary>
         /// Begin unloading a scene using an async method.
         /// </summary>


### PR DESCRIPTION
Problem:
SceneManager.GetSceneAt may return the wrong Scene Handle if the last scene is loaded outside of the Fishnet SceneManager queue. This is due to Scene loaded = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1); not properly capturing the newly loaded Scene Handle outside of the BeginLoadAsync function.

Using UnitySceneManager.GetSceneByName most likely doesn't support Scene Stacking.

Fix:
Provide BeginLoadAsync a callback that is able to capture the new scene handle immediately.