### PR TITLE
Fix templatePath (CreateNewNetworkBehaviour.cs)

### DIFF
--- a/Assets/FishNet/Runtime/Editor/NewNetworkBehaviour/CreateNewNetworkBehaviour.cs
+++ b/Assets/FishNet/Runtime/Editor/NewNetworkBehaviour/CreateNewNetworkBehaviour.cs
@@ -16,16 +16,7 @@ namespace FishNet.Editing.NewNetworkBehaviourScript
         [MenuItem("Assets/Create/NetworkBehaviour Script", false, -220)]
         private static void CreateNewAsset()
         {
-            string templatePath;
-            if (Directory.Exists(Application.dataPath + "/FishNet"))
-            {
-                templatePath = Application.dataPath + "/FishNet/Assets/FishNet/Runtime/Editor/NewNetworkBehaviour/template.txt";
-            }
-            else
-            {
-                templatePath = "Packages/com.firstgeargames.fishnet/Runtime/Editor/NewNetworkBehaviour/template.txt";
-            }
-            
+            string templatePath = Application.dataPath + "/FishnetNBTemplate.txt";
             if (!File.Exists(templatePath))
             {
 

--- a/Assets/FishNet/Runtime/Editor/NewNetworkBehaviour/SettingsProvider.cs
+++ b/Assets/FishNet/Runtime/Editor/NewNetworkBehaviour/SettingsProvider.cs
@@ -7,6 +7,7 @@ using UnitySettingsProviderAttribute = UnityEditor.SettingsProviderAttribute;
 using UnitySettingsProvider = UnityEditor.SettingsProvider;
 using FishNet.Configuring;
 using System.IO;
+using System.Xml.Linq;
 
 
 namespace FishNet.Editing.NewNetworkBehaviourScript
@@ -16,8 +17,7 @@ namespace FishNet.Editing.NewNetworkBehaviourScript
 
 
         private static PrefabGeneratorConfigurations _settings;
-        static string templatePath = Application.dataPath + "/FishNet/Assets/FishNet/Runtime/Editor/NewNetworkBehaviour/template.txt";
-
+        static string  templatePath;
         [UnitySettingsProvider]
         private static UnitySettingsProvider Create()
         {
@@ -39,7 +39,9 @@ namespace FishNet.Editing.NewNetworkBehaviourScript
 
         private static void OnGUI(string searchContext)
         {
-          if(GUILayout.Button("Edit template"))
+            if(templatePath == null) templatePath = Application.dataPath + "/FishnetNBTemplate.txt";
+
+            if (GUILayout.Button("Edit template"))
             {
                 if (!File.Exists(templatePath))
                 {
@@ -47,6 +49,9 @@ namespace FishNet.Editing.NewNetworkBehaviourScript
                 }
                 System.Diagnostics.Process.Start(templatePath);
             }
+           
+            EditorGUILayout.LabelField($"Template path:  {templatePath}");
+            
         }
 
        


### PR DESCRIPTION
Saving the script template in the FishNet main folder has proven to be a bad idea, as it may be a read-only directory depending on the installation choice. To simplify the process, I have decided to save the script template for CreateNetworkBehaviour next to the main FishNet Config file, in the default assets directory. This should also resolve the issue of editing the template file in the package release.

I have also added small label to indicate where template is located by default