### PR TITLE
Fix save cache count

### DIFF
--- a/Assets/FishNet/Runtime/Utility/Performance/DefaultObjectPool.cs
+++ b/Assets/FishNet/Runtime/Utility/Performance/DefaultObjectPool.cs
@@ -284,7 +284,7 @@ namespace FishNet.Utility.Performance
                     Dictionary<int, Stack<NetworkObject>> dict = new();
                     _cache.Add(dict);
                 }
-                _cacheCount = collectionId;
+                _cacheCount = _cache.Count;
             }
 
             Dictionary<int, Stack<NetworkObject>> dictionary = _cache[collectionId];


### PR DESCRIPTION
The default `collectionId` is 0.
When `GetCache(0, ...)` is called for the first time `_cache.Count` becomes 1 and `_cacheCount` remains 0.

As a result, we always go into the `if (collectionId >= _cacheCount)` check and try to fill `_cache` even though it is already filled.

And when we call `ClearPool()`, the `if (spawnableCollectionId >= _cacheCount)` check prevents us from going any further because `_cacheCount` is 0 and we will never clear the pool.

```cs
public void ClearPool(int spawnableCollectionId)
{
    if (spawnableCollectionId >= _cacheCount)
        return;
    // ....
}
```

With this fix we remember the real size of the cache and solve both problems - we don't try to re-fill the already filled cache and allow to clear the default pool collection.