### PR TITLE
Ordered found network object prefabs in generator

### DIFF
--- a/Assets/FishNet/Runtime/Editor/PrefabCollectionGenerator/Generator.cs
+++ b/Assets/FishNet/Runtime/Editor/PrefabCollectionGenerator/Generator.cs
@@ -325,6 +325,7 @@ namespace FishNet.Editing.PrefabCollectionGenerator
             foreach (SpecifiedFolder sf in specifiedFolders)
                 foundNobs.AddRange(GetNetworkObjects(sf, settings));
 
+            foundNobs = foundNobs.OrderBy(nob => nob.AssetPathHash).ToList();
             return foundNobs;
         }
 


### PR DESCRIPTION
Ordered found network object prefabs in generator to reduce churn in project repos (between Windows/macOS editors).