### PR TITLE
change to use static not kinematic at rigidbody 2d

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
@@ -825,7 +825,8 @@ namespace FishNet.Component.Transforming
                         _initializedRigidbodyInterpolation2d = c.interpolation;
 
                     bool isKinematic = CanMakeKinematic();
-                    c.bodyType = isKinematic ? RigidbodyType2D.Static : RigidbodyType2D.Dynamic;
+                    c.isKinematic = isKinematic;
+                    c.simulated = !isKinematic;
 
                     if (isKinematic)
                         c.interpolation = RigidbodyInterpolation2D.None;
@@ -1619,16 +1620,16 @@ namespace FishNet.Component.Transforming
                 //No more in buffer, see if can extrapolate.
                 else
                 {
-
-                    /* If everything matches up then end queue.
-                     * Otherwise let it play out until stuff
-                     * aligns. Generally the time remaining is enough
-                     * but every once in awhile something goes funky
-                     * and it's thrown off. */
-                    if (!HasChanged(td))
-                        _currentGoalData = null;
-                    OnInterpolationComplete?.Invoke();
-
+                    
+                        /* If everything matches up then end queue.
+                         * Otherwise let it play out until stuff
+                         * aligns. Generally the time remaining is enough
+                         * but every once in awhile something goes funky
+                         * and it's thrown off. */
+                        if (!HasChanged(td))
+                            _currentGoalData = null;
+                        OnInterpolationComplete?.Invoke();
+                        
                 }
             }
         }
@@ -2134,7 +2135,7 @@ namespace FishNet.Component.Transforming
             //Default value.
             next.ExtrapolationState = TransformData.ExtrapolateState.Disabled;
 
-
+            
         }
 
         /// <summary>

--- a/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
@@ -825,8 +825,7 @@ namespace FishNet.Component.Transforming
                         _initializedRigidbodyInterpolation2d = c.interpolation;
 
                     bool isKinematic = CanMakeKinematic();
-                    c.isKinematic = isKinematic;
-                    c.simulated = !isKinematic;
+                    c.bodyType = isKinematic ? RigidbodyType2D.Static : RigidbodyType2D.Dynamic;
 
                     if (isKinematic)
                         c.interpolation = RigidbodyInterpolation2D.None;

--- a/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkTransform/NetworkTransform.cs
@@ -825,8 +825,7 @@ namespace FishNet.Component.Transforming
                         _initializedRigidbodyInterpolation2d = c.interpolation;
 
                     bool isKinematic = CanMakeKinematic();
-                    c.isKinematic = isKinematic;
-                    c.simulated = !isKinematic;
+                    c.bodyType = isKinematic ? RigidbodyType2D.Static : RigidbodyType2D.Dynamic;
 
                     if (isKinematic)
                         c.interpolation = RigidbodyInterpolation2D.None;
@@ -1620,16 +1619,16 @@ namespace FishNet.Component.Transforming
                 //No more in buffer, see if can extrapolate.
                 else
                 {
-                    
-                        /* If everything matches up then end queue.
-                         * Otherwise let it play out until stuff
-                         * aligns. Generally the time remaining is enough
-                         * but every once in awhile something goes funky
-                         * and it's thrown off. */
-                        if (!HasChanged(td))
-                            _currentGoalData = null;
-                        OnInterpolationComplete?.Invoke();
-                        
+
+                    /* If everything matches up then end queue.
+                     * Otherwise let it play out until stuff
+                     * aligns. Generally the time remaining is enough
+                     * but every once in awhile something goes funky
+                     * and it's thrown off. */
+                    if (!HasChanged(td))
+                        _currentGoalData = null;
+                    OnInterpolationComplete?.Invoke();
+
                 }
             }
         }
@@ -2135,7 +2134,7 @@ namespace FishNet.Component.Transforming
             //Default value.
             next.ExtrapolationState = TransformData.ExtrapolateState.Disabled;
 
-            
+
         }
 
         /// <summary>

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
@@ -92,7 +92,7 @@ namespace FishNet.Component.Prediction
                 Velocity = Vector2.zero;
                 AngularVelocity = 0f;
                 Simulated = rb.simulated;
-                IsKinematic = rb.isKinematic;
+                IsKinematic = rb.bodyType == RigidbodyType2D.Static;
                 CollisionDetectionMode = rb.collisionDetectionMode;
             }
 
@@ -101,7 +101,7 @@ namespace FishNet.Component.Prediction
                 Velocity = rb.velocity;
                 AngularVelocity = rb.angularVelocity;
                 Simulated = rb.simulated;
-                IsKinematic = rb.isKinematic;
+                IsKinematic = rb.bodyType == RigidbodyType2D.Static;
                 CollisionDetectionMode = rb.collisionDetectionMode;
             }
         }
@@ -163,7 +163,7 @@ namespace FishNet.Component.Prediction
             List<Rigidbody> rigidbodies = CollectionCaches<Rigidbody>.RetrieveList();
             foreach (Rigidbody rb in rbs)
                 rigidbodies.Add(rb);
-            
+
             UpdateRigidbodies(rigidbodies);
 
             CollectionCaches<Rigidbody>.Store(rigidbodies);
@@ -171,7 +171,7 @@ namespace FishNet.Component.Prediction
         /// <summary>
         /// Assigns rigidbodies manually and initializes component.
         /// </summary>
-        private void UpdateRigidbodies(List<Rigidbody> rbs) 
+        private void UpdateRigidbodies(List<Rigidbody> rbs)
         {
             _rigidbodyDatas.Clear();
 
@@ -189,7 +189,7 @@ namespace FishNet.Component.Prediction
             List<Rigidbody2D> rigidbodies = CollectionCaches<Rigidbody2D>.RetrieveList();
             foreach (Rigidbody2D rb in rbs)
                 rigidbodies.Add(rb);
-            
+
             UpdateRigidbodies2D(rigidbodies);
 
             CollectionCaches<Rigidbody2D>.Store(rigidbodies);
@@ -197,7 +197,7 @@ namespace FishNet.Component.Prediction
         /// <summary>
         /// Assigns rigidbodies manually and initializes component.
         /// </summary>
-        private void UpdateRigidbodies2D(List<Rigidbody2D> rbs) 
+        private void UpdateRigidbodies2D(List<Rigidbody2D> rbs)
         {
             _rigidbody2dDatas.Clear();
 
@@ -220,7 +220,7 @@ namespace FishNet.Component.Prediction
             if (rbType == RigidbodyType.Rigidbody)
             {
                 List<Rigidbody> rigidbodies = CollectionCaches<Rigidbody>.RetrieveList();
-                
+
                 if (getInChildren)
                 {
                     Rigidbody[] rbs = t.GetComponentsInChildren<Rigidbody>();
@@ -233,7 +233,7 @@ namespace FishNet.Component.Prediction
                     if (rb != null)
                         rigidbodies.Add(rb);
                 }
-                
+
                 UpdateRigidbodies(rigidbodies);
                 CollectionCaches<Rigidbody>.Store(rigidbodies);
             }
@@ -241,7 +241,7 @@ namespace FishNet.Component.Prediction
             else
             {
                 List<Rigidbody2D> rigidbodies = CollectionCaches<Rigidbody2D>.RetrieveList();
-                
+
                 if (getInChildren)
                 {
                     Rigidbody2D[] rbs = t.GetComponentsInChildren<Rigidbody2D>();
@@ -254,7 +254,7 @@ namespace FishNet.Component.Prediction
                     if (rb != null)
                         rigidbodies.Add(rb);
                 }
-                
+
                 UpdateRigidbodies2D(rigidbodies);
                 CollectionCaches<Rigidbody2D>.Store(rigidbodies);
             }
@@ -327,8 +327,7 @@ namespace FishNet.Component.Prediction
                     rbData.Update(rb);
                     _rigidbody2dDatas[index] = rbData;
                     rb.collisionDetectionMode = CollisionDetectionMode2D.Discrete;
-                    rb.isKinematic = true;
-                    rb.simulated = false;
+                    rb.bodyType = RigidbodyType2D.Static;
 
                     return true;
                 }
@@ -408,11 +407,11 @@ namespace FishNet.Component.Prediction
                         return true;
 
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                    rb.isKinematic = rbData.IsKinematic;
+                    rb.bodyType = rbData.IsKinematic ? RigidbodyType2D.Static : RigidbodyType2D.Dynamic;
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                     rb.simulated = rbData.Simulated;
                     rb.collisionDetectionMode = rbData.CollisionDetectionMode;
-                    if (!rb.isKinematic)
+                    if (rb.bodyType != RigidbodyType2D.Static)
                     {
                         rb.velocity = rbData.Velocity;
                         rb.angularVelocity = rbData.AngularVelocity;

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
@@ -92,7 +92,7 @@ namespace FishNet.Component.Prediction
                 Velocity = Vector2.zero;
                 AngularVelocity = 0f;
                 Simulated = rb.simulated;
-                IsKinematic = rb.bodyType == RigidbodyType2D.Static;
+                IsKinematic = rb.isKinematic;
                 CollisionDetectionMode = rb.collisionDetectionMode;
             }
 
@@ -101,7 +101,7 @@ namespace FishNet.Component.Prediction
                 Velocity = rb.velocity;
                 AngularVelocity = rb.angularVelocity;
                 Simulated = rb.simulated;
-                IsKinematic = rb.bodyType == RigidbodyType2D.Static;
+                IsKinematic = rb.isKinematic;
                 CollisionDetectionMode = rb.collisionDetectionMode;
             }
         }
@@ -163,7 +163,7 @@ namespace FishNet.Component.Prediction
             List<Rigidbody> rigidbodies = CollectionCaches<Rigidbody>.RetrieveList();
             foreach (Rigidbody rb in rbs)
                 rigidbodies.Add(rb);
-
+            
             UpdateRigidbodies(rigidbodies);
 
             CollectionCaches<Rigidbody>.Store(rigidbodies);
@@ -171,7 +171,7 @@ namespace FishNet.Component.Prediction
         /// <summary>
         /// Assigns rigidbodies manually and initializes component.
         /// </summary>
-        private void UpdateRigidbodies(List<Rigidbody> rbs)
+        private void UpdateRigidbodies(List<Rigidbody> rbs) 
         {
             _rigidbodyDatas.Clear();
 
@@ -189,7 +189,7 @@ namespace FishNet.Component.Prediction
             List<Rigidbody2D> rigidbodies = CollectionCaches<Rigidbody2D>.RetrieveList();
             foreach (Rigidbody2D rb in rbs)
                 rigidbodies.Add(rb);
-
+            
             UpdateRigidbodies2D(rigidbodies);
 
             CollectionCaches<Rigidbody2D>.Store(rigidbodies);
@@ -197,7 +197,7 @@ namespace FishNet.Component.Prediction
         /// <summary>
         /// Assigns rigidbodies manually and initializes component.
         /// </summary>
-        private void UpdateRigidbodies2D(List<Rigidbody2D> rbs)
+        private void UpdateRigidbodies2D(List<Rigidbody2D> rbs) 
         {
             _rigidbody2dDatas.Clear();
 
@@ -220,7 +220,7 @@ namespace FishNet.Component.Prediction
             if (rbType == RigidbodyType.Rigidbody)
             {
                 List<Rigidbody> rigidbodies = CollectionCaches<Rigidbody>.RetrieveList();
-
+                
                 if (getInChildren)
                 {
                     Rigidbody[] rbs = t.GetComponentsInChildren<Rigidbody>();
@@ -233,7 +233,7 @@ namespace FishNet.Component.Prediction
                     if (rb != null)
                         rigidbodies.Add(rb);
                 }
-
+                
                 UpdateRigidbodies(rigidbodies);
                 CollectionCaches<Rigidbody>.Store(rigidbodies);
             }
@@ -241,7 +241,7 @@ namespace FishNet.Component.Prediction
             else
             {
                 List<Rigidbody2D> rigidbodies = CollectionCaches<Rigidbody2D>.RetrieveList();
-
+                
                 if (getInChildren)
                 {
                     Rigidbody2D[] rbs = t.GetComponentsInChildren<Rigidbody2D>();
@@ -254,7 +254,7 @@ namespace FishNet.Component.Prediction
                     if (rb != null)
                         rigidbodies.Add(rb);
                 }
-
+                
                 UpdateRigidbodies2D(rigidbodies);
                 CollectionCaches<Rigidbody2D>.Store(rigidbodies);
             }
@@ -327,7 +327,8 @@ namespace FishNet.Component.Prediction
                     rbData.Update(rb);
                     _rigidbody2dDatas[index] = rbData;
                     rb.collisionDetectionMode = CollisionDetectionMode2D.Discrete;
-                    rb.bodyType = RigidbodyType2D.Static;
+                    rb.isKinematic = true;
+                    rb.simulated = false;
 
                     return true;
                 }
@@ -407,11 +408,11 @@ namespace FishNet.Component.Prediction
                         return true;
 
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                    rb.bodyType = rbData.IsKinematic ? RigidbodyType2D.Static : RigidbodyType2D.Dynamic;
+                    rb.isKinematic = rbData.IsKinematic;
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                     rb.simulated = rbData.Simulated;
                     rb.collisionDetectionMode = rbData.CollisionDetectionMode;
-                    if (rb.bodyType != RigidbodyType2D.Static)
+                    if (!rb.isKinematic)
                     {
                         rb.velocity = rbData.Velocity;
                         rb.angularVelocity = rbData.AngularVelocity;

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyPauser.cs
@@ -92,7 +92,7 @@ namespace FishNet.Component.Prediction
                 Velocity = Vector2.zero;
                 AngularVelocity = 0f;
                 Simulated = rb.simulated;
-                IsKinematic = rb.isKinematic;
+                IsKinematic = rb.bodyType == RigidbodyType2D.Static;
                 CollisionDetectionMode = rb.collisionDetectionMode;
             }
 
@@ -101,7 +101,7 @@ namespace FishNet.Component.Prediction
                 Velocity = rb.velocity;
                 AngularVelocity = rb.angularVelocity;
                 Simulated = rb.simulated;
-                IsKinematic = rb.isKinematic;
+                IsKinematic = rb.bodyType == RigidbodyType2D.Static;
                 CollisionDetectionMode = rb.collisionDetectionMode;
             }
         }
@@ -327,8 +327,7 @@ namespace FishNet.Component.Prediction
                     rbData.Update(rb);
                     _rigidbody2dDatas[index] = rbData;
                     rb.collisionDetectionMode = CollisionDetectionMode2D.Discrete;
-                    rb.isKinematic = true;
-                    rb.simulated = false;
+                    rb.bodyType = RigidbodyType2D.Static;
 
                     return true;
                 }
@@ -407,12 +406,10 @@ namespace FishNet.Component.Prediction
                     if (rbData.IsKinematic || !rbData.Simulated)
                         return true;
 
-                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                    rb.isKinematic = rbData.IsKinematic;
-                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                    rb.bodyType = rbData.IsKinematic ? RigidbodyType2D.Static : RigidbodyType2D.Dynamic;
                     rb.simulated = rbData.Simulated;
                     rb.collisionDetectionMode = rbData.CollisionDetectionMode;
-                    if (!rb.isKinematic)
+                    if (rb.bodyType != RigidbodyType2D.Static)
                     {
                         rb.velocity = rbData.Velocity;
                         rb.angularVelocity = rbData.AngularVelocity;

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyState.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyState.cs
@@ -51,7 +51,7 @@ namespace FishNet.Component.Prediction
             Velocity = rb.velocity;
             AngularVelocity = rb.angularVelocity;
             Simulated = simulated;
-            IsKinematic = rb.isKinematic;
+            IsKinematic = rb.bodyType == RigidbodyType2D.Static;
         }
 
         public Rigidbody2DState(Rigidbody2D rb)
@@ -61,7 +61,7 @@ namespace FishNet.Component.Prediction
             Velocity = rb.velocity;
             AngularVelocity = rb.angularVelocity;
             Simulated = rb.simulated;
-            IsKinematic = rb.isKinematic;
+            IsKinematic = rb.bodyType == RigidbodyType2D.Static;
         }
     }
 

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyState.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyState.cs
@@ -8,7 +8,7 @@ namespace FishNet.Component.Prediction
     [UseGlobalCustomSerializer]
     [Preserve]
     public struct RigidbodyState
-    {        
+    {
         public Vector3 Position;
         public Quaternion Rotation;
         public bool IsKinematic;
@@ -51,7 +51,7 @@ namespace FishNet.Component.Prediction
             Velocity = rb.velocity;
             AngularVelocity = rb.angularVelocity;
             Simulated = simulated;
-            IsKinematic = rb.isKinematic;
+            IsKinematic = rb.bodyType == RigidbodyType2D.Static;
         }
 
         public Rigidbody2DState(Rigidbody2D rb)
@@ -61,7 +61,7 @@ namespace FishNet.Component.Prediction
             Velocity = rb.velocity;
             AngularVelocity = rb.angularVelocity;
             Simulated = rb.simulated;
-            IsKinematic = rb.isKinematic;
+            IsKinematic = rb.bodyType == RigidbodyType2D.Static;
         }
     }
 

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyState.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/RigidbodyState.cs
@@ -8,7 +8,7 @@ namespace FishNet.Component.Prediction
     [UseGlobalCustomSerializer]
     [Preserve]
     public struct RigidbodyState
-    {
+    {        
         public Vector3 Position;
         public Quaternion Rotation;
         public bool IsKinematic;
@@ -51,7 +51,7 @@ namespace FishNet.Component.Prediction
             Velocity = rb.velocity;
             AngularVelocity = rb.angularVelocity;
             Simulated = simulated;
-            IsKinematic = rb.bodyType == RigidbodyType2D.Static;
+            IsKinematic = rb.isKinematic;
         }
 
         public Rigidbody2DState(Rigidbody2D rb)
@@ -61,7 +61,7 @@ namespace FishNet.Component.Prediction
             Velocity = rb.velocity;
             AngularVelocity = rb.angularVelocity;
             Simulated = rb.simulated;
-            IsKinematic = rb.bodyType == RigidbodyType2D.Static;
+            IsKinematic = rb.isKinematic;
         }
     }
 


### PR DESCRIPTION
I'm not sure if you remember me making an issue with Simulation and Kinematics in Rigidbody 2D before.

But the conclusion at the time was that it was not wrong.
However, as I continued with the project, it was clear to me that it was wrong.

Clearly, the physics in 2D and 3D were behaving differently, and the physics in 2D seemed seriously broken.

So after investigating Unity's 2D physics, I found a solution.
I created a pull request so that you can easily check how the code changed and the changed files, so you can accept or reject it after seeing the results.

the video of original fishnet and changed one
first one is original and next one is new one


https://github.com/user-attachments/assets/ca7dcdc3-fc53-4463-af05-7878ca1cb417

original is default fishnet and new is changed one