### PR TITLE
Fixed IL Weaver for prediction failing

### DIFF
--- a/Assets/FishNet/CodeGenerating/Helpers/GeneralHelper.cs
+++ b/Assets/FishNet/CodeGenerating/Helpers/GeneralHelper.cs
@@ -1258,28 +1258,29 @@ namespace FishNet.CodeGenerating.Helping
                     foreach (FieldDefinition fieldDef in dataTr.FindAllSerializableFields(Session, null, WriterProcessor.EXCLUDED_ASSEMBLY_PREFIXES))
                     {
                         FieldReference fr = ImportReference(fieldDef);
-                        MethodDefinition recursiveMd = CreateEqualityComparer(fieldDef.FieldType);
+                        TypeReference fieldTypeRef = ImportReference( fieldDef.FieldType );
+                        MethodDefinition recursiveMd = CreateEqualityComparer(fieldTypeRef);
                         if (recursiveMd == null)
                             break;
                         processor.Append(GetLoadParameterInstruction(comparerMd, v0Pd));
                         processor.Emit(OpCodes.Ldfld, fr);
                         processor.Append(GetLoadParameterInstruction(comparerMd, v1Pd));
                         processor.Emit(OpCodes.Ldfld, fr);
-                        FinishTypeReferenceCompare(fieldDef.FieldType);
+                        FinishTypeReferenceCompare( fieldTypeRef );
                     }
 
                     // Properties.
                     foreach (PropertyDefinition propertyDef in dataTr.FindAllSerializableProperties(Session, null, WriterProcessor.EXCLUDED_ASSEMBLY_PREFIXES))
                     {
                         MethodReference getMr = Module.ImportReference(propertyDef.GetMethod);
-                        MethodDefinition recursiveMd = CreateEqualityComparer(getMr.ReturnType);
+                        MethodDefinition recursiveMd = CreateEqualityComparer( ImportReference( getMr.ReturnType ) );
                         if (recursiveMd == null)
                             break;
                         processor.Append(GetLoadParameterInstruction(comparerMd, v0Pd));
                         processor.Emit(OpCodes.Call, getMr);
                         processor.Append(GetLoadParameterInstruction(comparerMd, v1Pd));
                         processor.Emit(OpCodes.Call, getMr);
-                        FinishTypeReferenceCompare(propertyDef.PropertyType);
+                        FinishTypeReferenceCompare( ImportReference( propertyDef.PropertyType ) );
                     }
 
                     // Return true;

--- a/Assets/FishNet/CodeGenerating/Processing/Prediction/PredictionProcessor.cs
+++ b/Assets/FishNet/CodeGenerating/Processing/Prediction/PredictionProcessor.cs
@@ -713,6 +713,7 @@ namespace FishNet.CodeGenerating.Processing
             {
                 ILProcessor processor = replicateMd.Body.GetILProcessor();
                 ParameterDefinition replicateDataPd = replicateMd.Parameters[0];
+				replicateDataPd.ParameterType = Module.ImportReference( replicateDataPd.ParameterType );
                 MethodDefinition comparerMd = gh.CreateEqualityComparer(replicateDataPd.ParameterType);
                 gh.CreateIsDefaultComparer(replicateDataPd.ParameterType, comparerMd);
 
@@ -1007,6 +1008,7 @@ namespace FishNet.CodeGenerating.Processing
         private void ServerCreateReconcile(MethodDefinition reconcileMd, CreatedPredictionFields predictionFields, ref uint rpcCount)
         {
             ParameterDefinition reconcileDataPd = reconcileMd.Parameters[0];
+			reconcileDataPd.ParameterType = Module.ImportReference( reconcileDataPd.ParameterType );
             ParameterDefinition channelPd = reconcileMd.Parameters[1];
             ILProcessor processor = reconcileMd.Body.GetILProcessor();
 


### PR DESCRIPTION
Fixed IL Weaver for prediction failing when compiling a prediction method inside a .asmdef'd project

There is a extremely small, I really mean miniscule chance that it's been fixed already since I'm on a month old release, but let's not kid ourselves, no one wants to touch IL weaving code, so I doubt it.
Anyways this fixed a building issue I had with my project, all the replication methods were in a .asmdeffed project. After adding some imports it all builds fine.