### PR TITLE
Add implicit operator to NetworkBehavior

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkBehaviour/NetworkBehaviour.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkBehaviour/NetworkBehaviour.cs
@@ -60,6 +60,7 @@ namespace FishNet.Object
         /// NetworkObject this behaviour is for.
         /// </summary>
         public NetworkObject NetworkObject => _networkObjectCache;
+        public static implicit operator NetworkObject(NetworkBehaviour nb) => nb._networkObjectCache;
         #endregion
 
         #region Private.


### PR DESCRIPTION
Adds an implicit operator to convert a `NetworkBehavior` into a `NetworkObject` for quality of life.