### PR TITLE
Improve split packet reassembly: per-connection isolation, ordered fragments, deduplication and timeout

### DIFF
--- a/Assets/FishNet/Runtime/Connection/NetworkConnection.cs
+++ b/Assets/FishNet/Runtime/Connection/NetworkConnection.cs
@@ -2,6 +2,7 @@
 using FishNet.Documenting;
 using FishNet.Managing;
 using FishNet.Managing.Timing;
+using FishNet.Managing.Transporting;
 using FishNet.Object;
 using GameKit.Dependencies.Utilities;
 using System;
@@ -65,6 +66,15 @@ namespace FishNet.Connection
         /// LocalTick of the server when this connection was established. This value is not set for clients.
         /// </summary>
         internal uint ServerConnectionTick;
+        /// <summary>
+        /// Handles split packet reassembly for this connection.
+        /// </summary>
+        internal readonly SplitReader SplitReader = new();
+        /// <summary>
+        /// Next split identifier for outgoing split messages on this connection.
+        /// This value is only used on the server.
+        /// </summary>
+        internal int NextSplitId;
         #endregion
 
         #region Public.
@@ -477,6 +487,8 @@ namespace FishNet.Connection
             SetDisconnecting(false);
             Scenes.Clear();
             PredictedObjectIds.Clear();
+            SplitReader.Reset();
+            NextSplitId = 0;
             ResetPingPong();
             Observers_Reset();
             Prediction_Reset();

--- a/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Client/ClientManager.cs
@@ -447,14 +447,16 @@ namespace FishNet.Managing.Client
                     #endif
                     // Skip packetId.
                     reader.ReadPacketId();
+                    int splitId;
                     int expectedMessages;
-                    _splitReader.GetHeader(reader, out expectedMessages);
-                    _splitReader.Write(NetworkManager.TimeManager.LastPacketTick.LastRemoteTick, reader, expectedMessages);
+                    int partIndex;
+                    _splitReader.GetHeader(reader, out splitId, out expectedMessages, out partIndex);
+                    _splitReader.Write(splitId, reader, expectedMessages, partIndex);
                     /* If fullMessage returns 0 count then the split
                      * has not written fully yet. Otherwise, if there is
                      * data within then reinitialize reader with the
                      * full message. */
-                    ArraySegment<byte> fullMessage = _splitReader.GetFullMessage();
+                    ArraySegment<byte> fullMessage = _splitReader.GetFullMessage(splitId);
                     if (fullMessage.Count == 0)
                         return;
 
@@ -736,6 +738,7 @@ namespace FishNet.Managing.Client
         {
             using (_pm_OnPostTick.Auto())
             {
+                _splitReader.CheckSplitTimeout();
                 CheckServerTimeout();
             }
         }

--- a/Assets/FishNet/Runtime/Managing/Server/ServerManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Server/ServerManager.cs
@@ -218,10 +218,6 @@ namespace FishNet.Managing.Server
         /// </summary>
         private float _nextTimeoutCheckTime;
         /// <summary>
-        /// Used to read splits.
-        /// </summary>
-        private SplitReader _splitReader = new();
-        /// <summary>
         /// </summary>
         private NetworkTrafficStatistics _networkTrafficStatistics;
         #if DEVELOPMENT
@@ -424,6 +420,7 @@ namespace FishNet.Managing.Server
                     _nextClientTimeoutCheckIndex = 0;
 
                 NetworkConnection item = _clientsList[_nextClientTimeoutCheckIndex];
+                item.SplitReader.CheckSplitTimeout();
                 uint clientLocalTick = item.PacketTick.LocalTick;
                 /* If client tick has not been set yet then use the tick
                  * when they connected to the server. */
@@ -751,6 +748,17 @@ namespace FishNet.Managing.Server
             reader = ReaderPool.Retrieve(segment, NetworkManager, dataSource);
             uint tick = reader.ReadTickUnpacked();
             timeManager.LastPacketTick.Update(tick);
+
+            NetworkConnection conn;
+
+            /* Connection isn't available. This should never happen.
+             * Force an immediate disconnect. */
+            if (!Clients.TryGetValueIL2CPP(args.ConnectionId, out conn))
+            {
+                Kick(args.ConnectionId, KickReason.UnexpectedProblem, LoggingType.Error, $"ConnectionId {args.ConnectionId} not found within Clients.");
+                return;
+            }
+
             /* This is a special condition where a message may arrive split.
              * When this occurs buffer each packet until all packets are
              * received. */
@@ -762,28 +770,23 @@ namespace FishNet.Managing.Server
                 //Skip packetId.
                 reader.ReadPacketId();
 
+                int splitId;
                 int expectedMessages;
-                _splitReader.GetHeader(reader, out expectedMessages);
+                int partIndex;
+                conn.SplitReader.GetHeader(reader, out splitId, out expectedMessages, out partIndex);
                 //If here split message is to be read into splitReader.
-                _splitReader.Write(tick, reader, expectedMessages);
+                conn.SplitReader.Write(splitId, reader, expectedMessages, partIndex);
 
                 /* If fullMessage returns 0 count then the split
                  * has not written fully yet. Otherwise, if there is
                  * data within then reinitialize reader with the
                  * full message. */
-                ArraySegment<byte> fullMessage = _splitReader.GetFullMessage();
+                ArraySegment<byte> fullMessage = conn.SplitReader.GetFullMessage(splitId);
                 if (fullMessage.Count == 0)
                     return;
 
-                /* If here then all data has been received.
-                 * It's possible the client could have exceeded
-                 * maximum MTU but not the maximum number of splits.
-                 * This is because the length of each split
-                 * is not written, so we don't know how much data of the
-                 * final message actually belonged to the split vs
-                 * unrelated data added afterwards. We're going to cut
-                 * the client some slack in this situation for the sake
-                 * of keeping things simple. */
+                /* Full split payload has been reassembled and will now be parsed
+                 * as a normal incoming message. */
                 reader.Initialize(fullMessage, NetworkManager, dataSource);
             }
 
@@ -794,15 +797,7 @@ namespace FishNet.Managing.Server
                 #if DEVELOPMENT
                 NetworkManager.PacketIdHistory.ReceivedPacket(packetId, packetFromServer: false);
                 #endif
-                NetworkConnection conn;
 
-                /* Connection isn't available. This should never happen.
-                 * Force an immediate disconnect. */
-                if (!Clients.TryGetValueIL2CPP(args.ConnectionId, out conn))
-                {
-                    Kick(args.ConnectionId, KickReason.UnexpectedProblem, LoggingType.Error, $"ConnectionId {args.ConnectionId} not found within Clients. Connection will be kicked immediately.");
-                    return;
-                }
                 conn.LocalTick.Update(timeManager, tick, EstimatedTick.OldTickOption.Discard);
                 conn.PacketTick.Update(timeManager, tick, EstimatedTick.OldTickOption.SetLastRemoteTick);
                 /* If connection isn't authenticated and isn't a broadcast

--- a/Assets/FishNet/Runtime/Managing/Transporting/SplitReader.cs
+++ b/Assets/FishNet/Runtime/Managing/Transporting/SplitReader.cs
@@ -1,95 +1,181 @@
 ﻿using FishNet.Serializing;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace FishNet.Managing.Transporting
 {
-    internal class SplitReader
+    internal sealed class SplitReader
     {
         #region Private.
         /// <summary>
-        /// Tick split is for.
-        /// Tick must be a negative value so that it's impossible for the first tick to align.
+        /// Pending splits keyed by split identifier.
         /// </summary>
-        private long _tick = -1;
+        private readonly Dictionary<int, SplitData> _pendingSplits = new();
+
         /// <summary>
-        /// Expected number of splits.
+        /// How long in seconds a split may remain incomplete before being discarded.
         /// </summary>
-        private int _expectedMessages;
-        /// <summary>
-        /// Number of splits received so far.
-        /// </summary>
-        private ushort _receivedMessages;
-        /// <summary>
-        /// Writer containing split packet combined.
-        /// </summary>
-        private PooledWriter _writer = WriterPool.Retrieve();
+        private const float SPLIT_TIMEOUT = 3;
         #endregion
 
-        internal SplitReader()
+        private sealed class SplitData
         {
-            // Increase capacity to reduce the chance of resizing.
-            _writer.EnsureBufferCapacity(20000);
+            private const int ArrayThreshold = 64;
+
+            private readonly byte[][] _array;
+            private readonly Dictionary<int, byte[]> _dict;
+
+            public readonly int ExpectedMessages;
+            public int ReceivedCount;
+            public float LastReceivedTime;
+
+            public SplitData(int expectedMessages, float now)
+            {
+                ExpectedMessages = expectedMessages;
+                LastReceivedTime = now;
+
+                if (expectedMessages <= ArrayThreshold)
+                    _array = new byte[expectedMessages][];
+                else
+                    _dict = new Dictionary<int, byte[]>(expectedMessages);
+            }
+
+            public bool Contains(int part)
+            {
+                if (_array != null)
+                    return _array[part] != null;
+
+                return _dict.ContainsKey(part);
+            }
+
+            public void Set(int part, byte[] data)
+            {
+                if (_array != null)
+                    _array[part] = data;
+                else
+                    _dict[part] = data;
+            }
+
+            public bool TryGet(int part, out byte[] data)
+            {
+                if (_array != null)
+                {
+                    data = _array[part];
+                    return data != null;
+                }
+
+                return _dict.TryGetValue(part, out data);
+            }
+
+            public ArraySegment<byte> Assemble()
+            {
+                byte[][] orderedParts = new byte[ExpectedMessages][];
+                int totalSize = 0;
+
+                for (int i = 0; i < ExpectedMessages; i++)
+                {
+                    if (!TryGet(i, out byte[] part))
+                        return default;
+
+                    orderedParts[i] = part;
+                    totalSize += part.Length;
+                }
+
+                byte[] result = new byte[totalSize];
+                int position = 0;
+
+                for (int i = 0; i < orderedParts.Length; i++)
+                {
+                    byte[] part = orderedParts[i];
+                    Buffer.BlockCopy(part, 0, result, position, part.Length);
+                    position += part.Length;
+                }
+
+                return new ArraySegment<byte>(result);
+            }
         }
 
-        /// <summary>
-        /// Gets split header values.
-        /// </summary>
-        internal void GetHeader(PooledReader reader, out int expectedMessages)
+        internal void GetHeader(PooledReader reader, out int splitId, out int expectedMessages, out int partIndex)
         {
+            splitId = reader.ReadInt32();
             expectedMessages = reader.ReadInt32();
+            partIndex = reader.ReadInt32();
         }
 
-        /// <summary>
-        /// Combines split data.
-        /// </summary>
-        internal void Write(uint tick, PooledReader reader, int expectedMessages)
+        internal void Write(int splitId, PooledReader reader, int expectedMessages, int partIndex)
         {
-            // New tick which means new split.
-            if (tick != _tick)
-                Reset(tick, expectedMessages);
+            if (expectedMessages <= 0)
+                return;
 
-            /* This is just a guess as to how large the end
-             * message could be. If the writer is not the minimum
-             * of this length then resize it. */
-            int estimatedBufferSize = expectedMessages * 1500;
-            if (_writer.Capacity < estimatedBufferSize)
-                _writer.EnsureBufferCapacity(estimatedBufferSize);
-            /* Empty remainder of reader into the writer.
-             * It does not matter if parts of the reader
-             * contain data added after the split because
-             * once the split is fully combined the data
-             * is parsed as though it came in as one message,
-             * which is how data is normally read. */
-            ArraySegment<byte> data = reader.ReadArraySegment(reader.Remaining);
-            _writer.WriteArraySegment(data);
-            _receivedMessages++;
-        }
+            float now = Time.unscaledTime;
 
-        /// <summary>
-        /// Returns if all split messages have been received.
-        /// </summary>
-        /// <returns></returns>
-        internal ArraySegment<byte> GetFullMessage()
-        {
-            if (_receivedMessages < _expectedMessages)
+            if (!_pendingSplits.TryGetValue(splitId, out SplitData splitData))
             {
+                splitData = new SplitData(expectedMessages, now);
+                _pendingSplits[splitId] = splitData;
+            }
+            else if (splitData.ExpectedMessages != expectedMessages)
+            {
+                _pendingSplits.Remove(splitId);
+                return;
+            }
+
+            if (partIndex < 0 || partIndex >= splitData.ExpectedMessages)
+            {
+                _pendingSplits.Remove(splitId);
+                return;
+            }
+
+            if (splitData.Contains(partIndex))
+                return;
+
+            byte[] data = reader.ReadArraySegment(reader.Remaining).ToArray();
+            splitData.Set(partIndex, data);
+            splitData.ReceivedCount++;
+            splitData.LastReceivedTime = now;
+        }
+
+        internal ArraySegment<byte> GetFullMessage(int splitId)
+        {
+            if (!_pendingSplits.TryGetValue(splitId, out SplitData splitData))
                 return default;
-            }
-            else
-            {
-                ArraySegment<byte> segment = _writer.GetArraySegment();
-                Reset();
-                return segment;
-            }
+
+            if (splitData.ReceivedCount < splitData.ExpectedMessages)
+                return default;
+
+            ArraySegment<byte> result = splitData.Assemble();
+            _pendingSplits.Remove(splitId);
+            return result;
         }
 
-        private void Reset(uint tick = 0, int expectedMessages = 0)
+        internal void CheckSplitTimeout()
         {
-            _tick = tick;
-            _receivedMessages = 0;
-            _expectedMessages = expectedMessages;
-            _writer.Clear();
+            if (_pendingSplits.Count == 0)
+                return;
+
+            float now = Time.unscaledTime;
+            List<int> expired = null;
+
+            foreach (KeyValuePair<int, SplitData> kvp in _pendingSplits)
+            {
+                if (now - kvp.Value.LastReceivedTime > SPLIT_TIMEOUT)
+                {
+                    expired ??= new List<int>();
+                    expired.Add(kvp.Key);
+                }
+            }
+
+            if (expired == null)
+                return;
+
+            for (int i = 0; i < expired.Count; i++)
+                _pendingSplits.Remove(expired[i]);
+        }
+
+        internal void Reset()
+        {
+            _pendingSplits.Clear();
         }
     }
 }

--- a/Assets/FishNet/Runtime/Managing/Transporting/TransportManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Transporting/TransportManager.cs
@@ -109,6 +109,10 @@ namespace FishNet.Managing.Transporting
         /// </summary>
         private List<DisconnectingClient> _disconnectingClients = new();
         /// <summary>
+        /// Next split identifier for outgoing client-to-server split messages.
+        /// </summary>
+        private int _nextClientSplitId;
+        /// <summary>
         /// Lowest MTU of all transports for channels.
         /// </summary>
         private int[] _lowestMtus;
@@ -147,14 +151,22 @@ namespace FishNet.Managing.Transporting
         /// </summary>
         public const byte UNPACKED_SIZE_LENGTH = 4;
         /// <summary>
+        /// </summary>
+        private const byte SPLIT_ID_LENGTH = 4;
+        /// <summary>
         /// Number of bytes sent to indicate split count.
         /// </summary>
         private const byte SPLIT_COUNT_LENGTH = 4;
         /// <summary>
+        /// Number of bytes sent to indicate split part index.
+        /// </summary>
+        private const byte SPLIT_PARTINDEX_LENGTH = 4;
+        /// <summary>
         /// Number of bytes required for split data.
         /// </summary>
         /// // todo: This shouldn't have to include TickBytes but there is a parse error if it's not included. Figure out why.
-        public const byte SPLIT_INDICATOR_LENGTH = UNPACKED_TICK_LENGTH + PACKETID_LENGTH + SPLIT_COUNT_LENGTH;
+        public const byte SPLIT_INDICATOR_LENGTH =
+            UNPACKED_TICK_LENGTH + PACKETID_LENGTH + SPLIT_ID_LENGTH + SPLIT_COUNT_LENGTH + SPLIT_PARTINDEX_LENGTH;
         /// <summary>
         /// Number of channels supported.
         /// </summary>
@@ -253,6 +265,8 @@ namespace FishNet.Managing.Transporting
             // Reset toServer data.
             foreach (PacketBundle pb in _toServerBundles)
                 pb.Reset(resetSendLast: true);
+
+            _nextClientSplitId = 0;
         }
 
         /// <summary>
@@ -700,24 +714,37 @@ namespace FishNet.Managing.Transporting
             }
 
             byte channelId = (byte)Channel.Reliable;
-            PooledWriter headerWriter = WriterPool.Retrieve();
-            headerWriter.WritePacketIdUnpacked(PacketId.Split);
-            headerWriter.WriteInt32(requiredMessages);
-            ArraySegment<byte> headerSegment = headerWriter.GetArraySegment();
+
+            int splitId = (conn != null) ? conn.NextSplitId++ : _nextClientSplitId++;
 
             int writeIndex = 0;
-            bool firstWrite = true;
-            // Send to connection until everything is written.
+            int partIndex = 0;
+
             while (writeIndex < segment.Count)
             {
-                int headerReduction = 0;
-                if (firstWrite)
+                PooledWriter headerWriter = WriterPool.Retrieve();
+                headerWriter.WritePacketIdUnpacked(PacketId.Split);
+                headerWriter.WriteInt32(splitId);
+                headerWriter.WriteInt32(requiredMessages);
+                headerWriter.WriteInt32(partIndex);
+                ArraySegment<byte> headerSegment = headerWriter.GetArraySegment();
+
+                if (maxMessageSize <= 0)
                 {
-                    headerReduction = headerSegment.Count;
-                    firstWrite = false;
+                    headerWriter.Store();
+                    _networkManager.LogError($"Split message capacity is invalid ({maxMessageSize}). Check MTU and split overhead calculations.");
+                    return;
                 }
-                int chunkSize = Mathf.Min(segment.Count - writeIndex - headerReduction, maxMessageSize);
-                // Make a new array segment for the chunk that is getting split.
+
+                int remaining = segment.Count - writeIndex;
+                int chunkSize = Mathf.Min(remaining, maxMessageSize);
+                if (chunkSize <= 0)
+                {
+                    headerWriter.Store();
+                    _networkManager.LogError($"Computed split chunk size is invalid ({chunkSize}).");
+                    return;
+                }
+
                 ArraySegment<byte> splitSegment = new(segment.Array, segment.Offset + writeIndex, chunkSize);
 
                 // If connection is specified then it's going to a client.
@@ -733,10 +760,15 @@ namespace FishNet.Managing.Transporting
                     _toServerBundles[channelId].Write(splitSegment, false, orderType);
                 }
 
+                headerWriter.Store();
                 writeIndex += chunkSize;
+                partIndex++;
             }
 
-            headerWriter.Store();
+            if (partIndex != requiredMessages)
+            {
+                _networkManager.LogWarning($"Split send produced {partIndex} parts, but {requiredMessages} were expected. This may indicate an MTU calculation mismatch.");
+            }
         }
         #endregion
 

--- a/Assets/FishNet/Runtime/Managing/Transporting/TransportManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Transporting/TransportManager.cs
@@ -151,6 +151,7 @@ namespace FishNet.Managing.Transporting
         /// </summary>
         public const byte UNPACKED_SIZE_LENGTH = 4;
         /// <summary>
+        /// Number of bytes sent to indicate split ID.
         /// </summary>
         private const byte SPLIT_ID_LENGTH = 4;
         /// <summary>


### PR DESCRIPTION
- SplitReader is now per-connection (`NetworkConnection.SplitReader`) on the server instead of a single shared instance in ServerManager. This prevents tick collisions between clients where two connections could corrupt each other's reassembly buffers.
- Replaced tick-based keying with an explicit splitId counter (`NextSplitId` on `NetworkConnection` for server -> client, `_nextClientSplitId` in `TransportManager` for client -> server). This makes split identification unambiguous and independent of timing.
- Fragments are now stored and reassembled by index (partIndex) rather than appended sequentially. Out-of-order delivery no longer produces corrupted data.
- Added deduplication: duplicate fragment parts are silently dropped.
- Added metadata validation: if `expectedMessages` differs between parts of the same split, the entry is discarded.
- Added bounds validation on `partIndex` to guard against malformed packets.
- Added timeout cleanup (`CheckSplitTimeout`) to discard incomplete splits after 3 seconds, called via the existing `CheckClientTimeout` loop on the server and `TimeManager_OnPostTick` on the client.
- `SplitData` uses a dual-storage strategy: a fixed array for splits with ≤64 parts (fast index access), and a dictionary for larger splits (avoids large upfront allocations).
- `SPLIT_INDICATOR_LENGTH` updated to account for the new splitId and partIndex fields in the header.