### PR TITLE
feat: Use PhysicsScene2D.OverlapCollider in NetworkCollider2D

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/NetworkCollider2D.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/NetworkCollider2D.cs
@@ -121,14 +121,7 @@ namespace FishNet.Component.Prediction
                     continue;
 
                 // Number of hits from the checks.
-                // Number of hits from the checks.
-                int hits;
-                if (col is CircleCollider2D circleCollider)
-                    hits = GetCircleCollider2DHits(circleCollider, InteractableLayers);
-                else if (col is BoxCollider2D boxCollider)
-                    hits = GetBoxCollider2DHits(boxCollider, rotation, InteractableLayers);
-                else
-                    hits = 0;
+                int hits = PhysicsScene2D.OverlapCollider(col, _hits, InteractableLayers);
 
                 /* Check hits for enter/exit callbacks. */
                 for (int i = 0; i < hits; i++)
@@ -215,28 +208,7 @@ namespace FishNet.Component.Prediction
             }
         }
 
-        /// <summary>
-        /// Checks for circle collisions.
-        /// </summary>
-        /// <returns>Number of colliders hit.</returns>
-        private int GetCircleCollider2DHits(CircleCollider2D circleCollider, int layerMask)
-        {
-            circleCollider.GetCircleOverlapParams(out Vector3 center, out float radius);
-            radius += AdditionalSize;
-            return gameObject.scene.GetPhysicsScene2D().OverlapCircle(center, radius, _hits, layerMask);
-        }
 
-        /// <summary>
-        /// Checks for Box collisions.
-        /// </summary>
-        /// <returns>Number of colliders hit.</returns>
-        private int GetBoxCollider2DHits(BoxCollider2D boxCollider, Quaternion rotation, int layerMask)
-        {
-            boxCollider.GetBox2DOverlapParams(out Vector3 center, out Vector3 halfExtents);
-            Vector3 additional = Vector3.one * AdditionalSize;
-            halfExtents += additional;
-            return gameObject.scene.GetPhysicsScene2D().OverlapBox(center, halfExtents, rotation.z, _hits, layerMask);
-        }
 
         /// <summary>
         /// Finds colliders on this object to check.

--- a/Assets/FishNet/Runtime/Generated/Component/Prediction/NetworkCollider2D.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/Prediction/NetworkCollider2D.cs
@@ -121,7 +121,14 @@ namespace FishNet.Component.Prediction
                     continue;
 
                 // Number of hits from the checks.
-                int hits = PhysicsScene2D.OverlapCollider(col, _hits, InteractableLayers);
+                // Number of hits from the checks.
+                int hits;
+                if (col is CircleCollider2D circleCollider)
+                    hits = GetCircleCollider2DHits(circleCollider, InteractableLayers);
+                else if (col is BoxCollider2D boxCollider)
+                    hits = GetBoxCollider2DHits(boxCollider, rotation, InteractableLayers);
+                else
+                    hits = PhysicsScene2D.OverlapCollider(col, _hits, InteractableLayers);
 
                 /* Check hits for enter/exit callbacks. */
                 for (int i = 0; i < hits; i++)
@@ -208,7 +215,28 @@ namespace FishNet.Component.Prediction
             }
         }
 
+        /// <summary>
+        /// Checks for circle collisions.
+        /// </summary>
+        /// <returns>Number of colliders hit.</returns>
+        private int GetCircleCollider2DHits(CircleCollider2D circleCollider, int layerMask)
+        {
+            circleCollider.GetCircleOverlapParams(out Vector3 center, out float radius);
+            radius += AdditionalSize;
+            return gameObject.scene.GetPhysicsScene2D().OverlapCircle(center, radius, _hits, layerMask);
+        }
 
+        /// <summary>
+        /// Checks for Box collisions.
+        /// </summary>
+        /// <returns>Number of colliders hit.</returns>
+        private int GetBoxCollider2DHits(BoxCollider2D boxCollider, Quaternion rotation, int layerMask)
+        {
+            boxCollider.GetBox2DOverlapParams(out Vector3 center, out Vector3 halfExtents);
+            Vector3 additional = Vector3.one * AdditionalSize;
+            halfExtents += additional;
+            return gameObject.scene.GetPhysicsScene2D().OverlapBox(center, halfExtents, rotation.z, _hits, layerMask);
+        }
 
         /// <summary>
         /// Finds colliders on this object to check.


### PR DESCRIPTION
Use PhysicsScene2D.OverlapCollider as a fallback to allow NetworkCollider2D to work with any 2D collider shape. Existing circle/box logic is kept because it uses `AdditionalSize`.

See discussion: https://github.com/FirstGearGames/FishNet/discussions/728

Note: A similar change is not possible for 3D colliders, as Unity's PhysicsScene does not provide a generic OverlapCollider method.