### PR TITLE
Fix prefab objects generator cannot include folders with spaces in the path

### DIFF
--- a/Assets/FishNet/Runtime/Editor/PrefabCollectionGenerator/SettingsProvider.cs
+++ b/Assets/FishNet/Runtime/Editor/PrefabCollectionGenerator/SettingsProvider.cs
@@ -14,7 +14,7 @@ namespace FishNet.Editing.PrefabCollectionGenerator
 {
     internal static class SettingsProvider
     {
-        private static readonly Regex SlashRegex = new(@"[\\// ]");
+        private static readonly Regex SlashRegex = new(@"[\\//]");
         private static PrefabGeneratorConfigurations _settings;
         private static GUIContent _folderIcon;
         private static GUIContent _deleteIcon;


### PR DESCRIPTION
The regular expression defining the directory separator contained a space at the end. This caused the path to become invalid for all folders included in the "included folders" list that had a space in their path, as all spaces were replaced with the separator.