### PR TITLE
Refactor NetworkBehaviour ToString method for null safety

### DIFF
--- a/Assets/FishNet/Runtime/Object/NetworkBehaviour/NetworkBehaviour.cs
+++ b/Assets/FishNet/Runtime/Object/NetworkBehaviour/NetworkBehaviour.cs
@@ -101,7 +101,10 @@ namespace FishNet.Object
         /// <returns></returns>
         public override string ToString()
         {
-            return $"Name [{gameObject.name}] ComponentId [{ComponentIndex}] NetworkObject Name [{_networkObjectCache.name}] NetworkObject Id [{_networkObjectCache.ObjectId}]";
+            string networkObjectName = _networkObjectCache?.name ?? "Null";
+            int networkObjectId = _networkObjectCache?.ObjectId ?? -1;
+        
+            return $"Name [{gameObject.name}] ComponentId [{ComponentIndex}] NetworkObject Name [{networkObjectName}] NetworkObject Id [{networkObjectId}]";
         }
 
         [MakePublic]


### PR DESCRIPTION
This makes `NetworkBehaviour.ToString()` null-safe

Which fixes issues with different editor packages that use custom inspectors calling ToString