### PR TITLE
Fix Unity 6.5 SceneHandle and Object ID compile errors

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/SceneLookupData.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneLookupData.cs
@@ -1,4 +1,5 @@
-﻿using GameKit.Dependencies.Utilities;
+﻿using FishNet.Utility;
+using GameKit.Dependencies.Utilities;
 using System;
 using System.Collections.Generic;
 using UnityEngine.SceneManagement;
@@ -24,7 +25,6 @@ namespace FishNet.Managing.Scened
             return names;
         }
 
-        
         /// <summary>
         /// Returns Names from SceneLookupData.
         /// </summary>
@@ -46,13 +46,33 @@ namespace FishNet.Managing.Scened
     public class SceneLookupData : IEquatable<SceneLookupData>
     {
         /// <summary>
-        /// Handle of the scene. If value is 0, then handle is not used.
+        /// Raw handle of the scene. If value is 0, then handle is not used.
         /// </summary>
-        public int Handle;
+        private ulong _rawHandle;
+
+        /// <summary>
+        /// Legacy 32-bit handle view.
+        /// </summary>
+        public int Handle
+        {
+            get => unchecked((int)_rawHandle);
+            set => _rawHandle = unchecked((uint)value);
+        }
+
+        /// <summary>
+        /// Raw scene handle value.
+        /// </summary>
+        public ulong RawHandle
+        {
+            get => _rawHandle;
+            set => _rawHandle = value;
+        }
+
         /// <summary>
         /// Name of the scene.
         /// </summary>
         public string Name = string.Empty;
+
         /// <summary>
         /// Returns the scene name without a directory path should one exist.
         /// </summary>
@@ -62,16 +82,17 @@ namespace FishNet.Managing.Scened
             {
                 if (string.IsNullOrEmpty(Name))
                     return string.Empty;
-                
+
                 string name = System.IO.Path.GetFileName(Name);
                 return RemoveUnityExtension(name);
             }
         }
+
         /// <summary>
         /// Returns if this data is valid for use.
         /// Being valid does not mean that the scene exist, rather that there is enough data to try and lookup a scene.
         /// </summary>
-        public bool IsValid => Name != string.Empty || Handle != 0;
+        public bool IsValid => Name != string.Empty || RawHandle != 0;
 
         #region Const
         /// <summary>
@@ -89,7 +110,7 @@ namespace FishNet.Managing.Scened
         /// <param name = "scene">Scene to generate from.</param>
         public SceneLookupData(Scene scene)
         {
-            Handle = scene.handle;
+            RawHandle = UnityCompatibility.GetSceneHandleRaw(scene);
             Name = scene.name;
         }
 
@@ -111,11 +132,29 @@ namespace FishNet.Managing.Scened
 
         /// <summary>
         /// </summary>
+        /// <param name = "handle">Raw scene handle to generate from.</param>
+        public SceneLookupData(ulong handle)
+        {
+            RawHandle = handle;
+        }
+
+        /// <summary>
+        /// </summary>
         /// <param name = "handle">Scene handle to generate from.</param>
         /// <param name = "name">Name to generate from if handle is 0.</param>
         public SceneLookupData(int handle, string name)
         {
             Handle = handle;
+            Name = name;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name = "handle">Raw scene handle to generate from.</param>
+        /// <param name = "name">Name to generate from if handle is 0.</param>
+        public SceneLookupData(ulong handle, string name)
+        {
+            RawHandle = handle;
             Name = name;
         }
 
@@ -159,10 +198,10 @@ namespace FishNet.Managing.Scened
                 return false;
 
             // True if both handles are empty.
-            bool bothHandlesEmpty = Handle == 0 && sld.Handle == 0;
+            bool bothHandlesEmpty = RawHandle == 0 && sld.RawHandle == 0;
 
             // If both have handles and they match.
-            if (!bothHandlesEmpty && sld.Handle == Handle)
+            if (!bothHandlesEmpty && sld.RawHandle == RawHandle)
                 return true;
             // If neither have handles and name matches.
             else if (bothHandlesEmpty && sld.Name == Name)
@@ -175,7 +214,7 @@ namespace FishNet.Managing.Scened
         public override int GetHashCode()
         {
             int hashCode = 2053068273;
-            hashCode = hashCode * -1521134295 + Handle.GetHashCode();
+            hashCode = hashCode * -1521134295 + RawHandle.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
             return hashCode;
         }
@@ -187,7 +226,7 @@ namespace FishNet.Managing.Scened
 
         public override string ToString()
         {
-            return $"Name {Name}, Handle {Handle}";
+            return $"Name {Name}, Handle {RawHandle}";
             // return base.ToString();
         }
         #endregion
@@ -215,6 +254,13 @@ namespace FishNet.Managing.Scened
         public static SceneLookupData CreateData(int handle) => new(handle);
 
         /// <summary>
+        /// Returns a new SceneLookupData.
+        /// </summary>
+        /// <param name = "scene">Raw scene handle to create from.</param>
+        /// <returns></returns>
+        public static SceneLookupData CreateData(ulong handle) => new(handle);
+
+        /// <summary>
         /// Returns a SceneLookupData collection.
         /// </summary>
         /// <param name = "scenes">Scenes to create from.</param>
@@ -234,6 +280,13 @@ namespace FishNet.Managing.Scened
         /// <param name = "handles">Scene handles to create from.</param>
         /// <returns></returns>
         public static SceneLookupData[] CreateData(List<int> handles) => CreateData(handles.ToArray());
+
+        /// <summary>
+        /// Returns a SceneLookupData collection.
+        /// </summary>
+        /// <param name = "handles">Raw scene handles to create from.</param>
+        /// <returns></returns>
+        public static SceneLookupData[] CreateData(List<ulong> handles) => CreateData(handles.ToArray());
 
         /// <summary>
         /// Returns a SceneLookupData collection.
@@ -297,12 +350,12 @@ namespace FishNet.Managing.Scened
                     for (int i = 0; i < result.Count; i++)
                     {
                         bool nameMatches = result[i].Name == item.Name;
-                        bool handleMatches = result[i].Handle == item.Handle;
+                        bool handleMatches = result[i].RawHandle == item.RawHandle;
                         // Handle is the same (could be 0 handle).
                         if (handleMatches)
                         {
                             // If handle matches and not default then the same scene was added multiple times.
-                            if (item.Handle != 0)
+                            if (item.RawHandle != 0)
                                 failingIndex = i;
                         }
                         // Name is the same.
@@ -365,6 +418,32 @@ namespace FishNet.Managing.Scened
 
             return result.ToArray();
         }
+
+        /// <summary>
+        /// Returns a SceneLookupData collection.
+        /// </summary>
+        /// <param name = "handles">Raw scene handles to create from.</param>
+        /// <returns></returns>
+        public static SceneLookupData[] CreateData(ulong[] handles)
+        {
+            bool invalidFound = false;
+            List<SceneLookupData> result = new();
+            foreach (ulong item in handles)
+            {
+                if (item == 0)
+                {
+                    invalidFound = true;
+                    continue;
+                }
+
+                result.Add(CreateData(item));
+            }
+
+            if (invalidFound)
+                NetworkManagerExtensions.LogWarning(INVALID_SCENE);
+
+            return result.ToArray();
+        }
         #endregion
 
         /// <summary>
@@ -390,7 +469,7 @@ namespace FishNet.Managing.Scened
         {
             foundByHandle = false;
 
-            if (Handle == 0 && string.IsNullOrEmpty(NameOnly))
+            if (RawHandle == 0 && string.IsNullOrEmpty(NameOnly))
             {
                 NetworkManagerExtensions.LogWarning("Scene handle and name is unset; scene cannot be returned.");
                 return default;
@@ -398,11 +477,11 @@ namespace FishNet.Managing.Scened
 
             Scene result = default;
 
-            // Lookup my handle.
-            if (Handle != 0)
+            // Lookup by handle first.
+            if (RawHandle != 0)
             {
-                result = SceneManager.GetScene(Handle);
-                if (result.handle != 0)
+                result = GetSceneByRawHandle(RawHandle);
+                if (UnityCompatibility.HasValidSceneHandle(result))
                     foundByHandle = true;
             }
 
@@ -411,6 +490,22 @@ namespace FishNet.Managing.Scened
                 result = SceneManager.GetScene(NameOnly, null, warnIfDuplicates);
 
             return result;
+        }
+
+        /// <summary>
+        /// Returns a currently loaded scene by raw scene handle.
+        /// </summary>
+        private static Scene GetSceneByRawHandle(ulong rawHandle)
+        {
+            int count = UnityEngine.SceneManagement.SceneManager.sceneCount;
+            for (int i = 0; i < count; i++)
+            {
+                Scene scene = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
+                if (scene.IsValid() && UnityCompatibility.GetSceneHandleRaw(scene) == rawHandle)
+                    return scene;
+            }
+
+            return default;
         }
     }
 }

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -5,6 +5,7 @@ using FishNet.Managing.Server;
 using FishNet.Object;
 using FishNet.Serializing.Helping;
 using FishNet.Transporting;
+using FishNet.Utility;
 using GameKit.Dependencies.Utilities;
 using GameKit.Dependencies.Utilities.Types;
 using System;
@@ -34,11 +35,11 @@ namespace FishNet.Managing.Scened
             /// <summary>
             /// Scene handles which have clients that have not yet confirmed the loading status.
             /// </summary>
-            private Dictionary<int, HashSet<NetworkConnection>> _scenesWithPendingLoads = new();
+            private Dictionary<ulong, HashSet<NetworkConnection>> _scenesWithPendingLoads = new();
             /// <summary>
             /// Clients with pending loads, and each scene handle pending.
             /// </summary>
-            private Dictionary<NetworkConnection, List<int>> _clientsWithPendingLoads = new();
+            private Dictionary<NetworkConnection, List<ulong>> _clientsWithPendingLoads = new();
             /// <summary>
             /// Clients which have been sent the initial scene load with no scenes specified.
             /// </summary>
@@ -49,11 +50,11 @@ namespace FishNet.Managing.Scened
             /// <summary>
             /// Adds a pending load for a client.
             /// </summary>
-            public void AddClientToScene(NetworkConnection connection, int sceneHandle)
+            public void AddClientToScene(NetworkConnection connection, ulong sceneHandle)
             {
                 /* The client has 1 or more pending loads already. See
                  * if the specified scene is already pending. */
-                if (_clientsWithPendingLoads.TryGetValueIL2CPP(connection, out List<int> sceneList))
+                if (_clientsWithPendingLoads.TryGetValueIL2CPP(connection, out List<ulong> sceneList))
                 {
                     //Scene is already marked for the connection.
                     if (sceneList.Contains(sceneHandle))
@@ -81,14 +82,14 @@ namespace FishNet.Managing.Scened
             /// Removes a client from all pending loads.
             /// </summary
             /// <returns>Scene handles which no longer have clients pending loads.</returns>
-            internal List<int> RemoveClientFromAllScenes(NetworkConnection conn)
+            internal List<ulong> RemoveClientFromAllScenes(NetworkConnection conn)
             {
-                List<int> emptyScenes = new();
+                List<ulong> emptyScenes = new();
 
-                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<int> sceneList))
+                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<ulong> sceneList))
                     return emptyScenes;
 
-                foreach (int sceneHandle in sceneList)
+                foreach (ulong sceneHandle in sceneList)
                 {
                     /* If the scene is in the clients list then it should
                      * be in scenesWithPendingLoads. This is a safety check but
@@ -113,7 +114,7 @@ namespace FishNet.Managing.Scened
             /// </summary
             /// <param name="sceneHasNoPendingLoads">Becomes true if the scene which the connection is being removed from has no more pending loads.</param>
             /// <returns>True if the client had the specified scene as pending.</returns>
-            internal bool RemoveClientFromScene(NetworkConnection conn, int sceneHandle, out bool sceneHasNoPendingLoads)
+            internal bool RemoveClientFromScene(NetworkConnection conn, ulong sceneHandle, out bool sceneHasNoPendingLoads)
             {
                 // The scene has does not have any pending clients.
                 if (!_scenesWithPendingLoads.TryGetValueIL2CPP(sceneHandle, out HashSet<NetworkConnection> connectionsLoadingScene))
@@ -136,7 +137,7 @@ namespace FishNet.Managing.Scened
                 /* If client does not have any pending loads then
                  * there is nothing to remove, which means the requested
                  * scene still has clients in it. */
-                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<int> sceneList))
+                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<ulong> sceneList))
                 {
                     sceneHasNoPendingLoads = false;
                     return false;
@@ -176,7 +177,7 @@ namespace FishNet.Managing.Scened
             /// <summary>
             /// Returns if a scene has any number of clients still pending load.
             /// </summary>
-            internal bool HasSceneAnyPendingLoads(int sceneHandle) => _scenesWithPendingLoads.TryGetValueIL2CPP(sceneHandle, out _);
+            internal bool HasSceneAnyPendingLoads(ulong sceneHandle) => _scenesWithPendingLoads.TryGetValueIL2CPP(sceneHandle, out _);
 
             /// <summary>
             /// Clears all information.
@@ -576,7 +577,7 @@ namespace FishNet.Managing.Scened
             };
 
             foreach (SceneLookupData lookupData in sceneLookupData)
-                _pendingClientSceneLoads.AddClientToScene(connection, lookupData.Handle);
+                _pendingClientSceneLoads.AddClientToScene(connection, lookupData.RawHandle);
 
             connection.Broadcast(msg, requireAuthenticated: true);
         }
@@ -635,7 +636,7 @@ namespace FishNet.Managing.Scened
                 /* True if SceneConnections has no more connections
                  * in its scene, as well if the scene checked is in
                  * has no other clients pending load confirmation. */
-                bool isSceneNowEmpty = removed && hs.Count == 0 && !_pendingClientSceneLoads.HasSceneAnyPendingLoads(scene.handle);
+                bool isSceneNowEmpty = removed && hs.Count == 0 && !_pendingClientSceneLoads.HasSceneAnyPendingLoads(UnityCompatibility.GetSceneHandleRaw(scene));
 
                 //True if not a global scene and not in scenes to be manually unloaded.
                 bool notGlobalAndNotManualUnload = !IsGlobalScene(scene) && !_manualUnloadScenes.Contains(scene);
@@ -691,9 +692,9 @@ namespace FishNet.Managing.Scened
                 foreach (SceneLookupData item in msg.SceneLookupDatas)
                 {
                     //Make sure the sceneId is pending.
-                    if (!_pendingClientSceneLoads.RemoveClientFromScene(conn, item.Handle, out _))
+                    if (!_pendingClientSceneLoads.RemoveClientFromScene(conn, item.RawHandle, out _))
                     {
-                        KickClient($"Client {conn.ToString()} sent a scene load response for handle [{item.Handle}], but client was not sent a load for this handle.");
+                        KickClient($"Client {conn.ToString()} sent a scene load response for handle [{item.RawHandle}], but client was not sent a load for this handle.");
                         break;
                     }
 
@@ -1058,7 +1059,7 @@ namespace FishNet.Managing.Scened
                 /* Scene queue data scenes.
                  * All scenes in the scene queue data whether they will be loaded or not. */
                 List<string> requestedLoadSceneNames = new();
-                List<int> requestedLoadSceneHandles = new();
+                List<ulong> requestedLoadSceneHandles = new();
 
                 /* Make a null filled array. This will be populated
                  * using loaded scenes, or already loaded (eg cannot be loaded) scenes. */
@@ -1081,7 +1082,7 @@ namespace FishNet.Managing.Scened
                     {
                         requestedLoadSceneNames.Add(s.name);
                         if (byHandle)
-                            requestedLoadSceneHandles.Add(s.handle);
+                            requestedLoadSceneHandles.Add(UnityCompatibility.GetSceneHandleRaw(s));
                     }
 
                     if (CanLoadScene(data, lookupData))
@@ -1124,7 +1125,7 @@ namespace FishNet.Managing.Scened
                 }
 
                 // Connection scenes handles prior to ConnectionScenes being modified.
-                List<int> connectionScenesHandlesCached = new();
+                List<ulong> connectionScenesHandlesCached = new();
                 // If replacing scenes.
                 if (replaceScenes != ReplaceOption.None)
                 {
@@ -1137,7 +1138,7 @@ namespace FishNet.Managing.Scened
                     {
                         Scene[] sceneConnectionsKeys = SceneConnections.Keys.ToArray();
                         for (int i = 0; i < sceneConnectionsKeys.Length; i++)
-                            connectionScenesHandlesCached.Add(sceneConnectionsKeys[i].handle);
+                            connectionScenesHandlesCached.Add(UnityCompatibility.GetSceneHandleRaw(sceneConnectionsKeys[i]));
 
                         // If global then remove all connections from all scenes.
                         if (data.ScopeType == SceneScopeType.Global)
@@ -1155,7 +1156,7 @@ namespace FishNet.Managing.Scened
                     else
                     {
                         foreach (Scene s in NetworkManager.ClientManager.Connection.Scenes)
-                            connectionScenesHandlesCached.Add(s.handle);
+                            connectionScenesHandlesCached.Add(UnityCompatibility.GetSceneHandleRaw(s));
                     }
                 }
 
@@ -1181,7 +1182,7 @@ namespace FishNet.Managing.Scened
                         if (requestedLoadSceneNames.Contains(s.name))
                             continue;
                         // Same as above but using handles.
-                        if (requestedLoadSceneHandles.Contains(s.handle))
+                        if (requestedLoadSceneHandles.Contains(UnityCompatibility.GetSceneHandleRaw(s)))
                             continue;
                         /* Cannot unload global scenes. If
                          * replace scenes was used for a global
@@ -1193,7 +1194,7 @@ namespace FishNet.Managing.Scened
                         if (_manualUnloadScenes.Contains(s))
                             continue;
 
-                        bool inScenesCache = connectionScenesHandlesCached.Contains(s.handle);
+                        bool inScenesCache = connectionScenesHandlesCached.Contains(UnityCompatibility.GetSceneHandleRaw(s));
                         HashSet<NetworkConnection> conns;
                         bool inScenesCurrent = SceneConnections.ContainsKey(s);
                         // If was in scenes previously but isnt now then no connections reside in the scene.
@@ -1328,7 +1329,7 @@ namespace FishNet.Managing.Scened
                         /* If the first lookup data contains a handle and the scene
                          * is found for that handle then use that as the moved to scene.
                          * Nobs always move to the first specified scene. */
-                        if (sceneLoadData.SceneLookupDatas[0].Handle != 0 && !string.IsNullOrEmpty(firstScene.name))
+                        if (sceneLoadData.SceneLookupDatas[0].RawHandle != 0 && !string.IsNullOrEmpty(firstScene.name))
                         {
                             firstValidScene = firstScene;
                         }
@@ -1503,7 +1504,7 @@ namespace FishNet.Managing.Scened
                     {
                         SceneLookupData[] slds = msg.QueueData.SceneLoadData.SceneLookupDatas;
                         foreach (SceneLookupData sld in slds)
-                            AddPendingLoad(lConns, sld.Handle);
+                            AddPendingLoad(lConns, sld.RawHandle);
                     }
                 }
                 /* If running as client then send a message
@@ -2247,11 +2248,21 @@ namespace FishNet.Managing.Scened
         /// <returns></returns>
         public static Scene GetScene(int sceneHandle)
         {
+            return GetScene(unchecked((uint)sceneHandle));
+        }
+
+        /// <summary>
+        /// Returns a scene by raw handle.
+        /// </summary>
+        /// <param name = "sceneHandle"></param>
+        /// <returns></returns>
+        public static Scene GetScene(ulong sceneHandle)
+        {
             int count = UnitySceneManager.sceneCount;
             for (int i = 0; i < count; i++)
             {
                 Scene s = UnitySceneManager.GetSceneAt(i);
-                if (s.handle == sceneHandle)
+                if (UnityCompatibility.GetSceneHandleRaw(s) == sceneHandle)
                     return s;
             }
 
@@ -2354,7 +2365,7 @@ namespace FishNet.Managing.Scened
             {
                 Scene s = scenes[i];
 
-                if (SceneConnections.TryGetValueIL2CPP(s, out _) || _pendingClientSceneLoads.HasSceneAnyPendingLoads(s.handle))
+                if (SceneConnections.TryGetValueIL2CPP(s, out _) || _pendingClientSceneLoads.HasSceneAnyPendingLoads(UnityCompatibility.GetSceneHandleRaw(s)))
                 {
                     scenes.RemoveAt(i);
                     i--;
@@ -2365,7 +2376,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// Adds a pending load for a connection.
         /// </summary>
-        private void AddPendingLoad(NetworkConnection[] conns, int sceneHandle)
+        private void AddPendingLoad(NetworkConnection[] conns, ulong sceneHandle)
         {
             foreach (NetworkConnection c in conns)
             {

--- a/Assets/FishNet/Runtime/Managing/Scened/UnloadedScene.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/UnloadedScene.cs
@@ -1,19 +1,26 @@
-﻿using UnityEngine.SceneManagement;
+﻿using FishNet.Utility;
+using UnityEngine.SceneManagement;
 
 namespace FishNet.Managing.Scened
 {
     public struct UnloadedScene
     {
         public readonly string Name;
-        public readonly int Handle;
+        public readonly ulong Handle;
 
         public UnloadedScene(Scene s)
         {
             Name = s.name;
-            Handle = s.handle;
+            Handle = UnityCompatibility.GetSceneHandleRaw(s);
         }
 
         public UnloadedScene(string name, int handle)
+        {
+            Name = name;
+            Handle = unchecked((uint)handle);
+        }
+
+        public UnloadedScene(string name, ulong handle)
         {
             Name = name;
             Handle = handle;
@@ -30,7 +37,7 @@ namespace FishNet.Managing.Scened
             for (int i = 0; i < loadedScenes; i++)
             {
                 Scene s = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
-                if (s.IsValid() && s.handle == Handle)
+                if (s.IsValid() && UnityCompatibility.GetSceneHandleRaw(s) == Handle)
                     return s;
             }
 

--- a/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -155,10 +155,12 @@ namespace FishNet.Observing
                 foreach (ObserverCondition item in _observerConditions)
                 {
                     item.Deinitialize(destroyed);
-                    /* Use GetInstanceId to ensure the object is actually
-                     * instantiated. If Id is negative, then it's instantiated
-                     * and not a reference to the original object. */
-                    if (destroyed && item.GetInstanceID() < 0)
+
+                    /* Conditions are replaced with instantiated copies during Initialize.
+                     * Destroy the runtime copies when this observer is being destroyed.
+                     * Do not rely on InstanceID sign because InstanceID is obsolete in Unity 6.5+.
+                     */
+                    if (destroyed)
                         Destroy(item);
                 }
 
@@ -309,10 +311,10 @@ namespace FishNet.Observing
             if (!_initialized)
             {
                 string goName = gameObject == null ? "Empty" : gameObject.name;
-                
+
                 NetworkManager nm = _networkObject == null ? null : _networkObject.NetworkManager;
                 nm.LogError($"{GetType().Name} is not initialized on NetworkObject [{goName}]. RebuildObservers should not be called. If you are able to reproduce this error consistently please report this issue.");
-                
+
                 return ObserverStateChange.Unchanged;
             }
 

--- a/Assets/FishNet/Runtime/Serializing/Helping/Comparers.cs
+++ b/Assets/FishNet/Runtime/Serializing/Helping/Comparers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using FishNet.Utility;
+using System;
 using System.Collections.Generic;
 using UnityEngine.SceneManagement;
 
@@ -10,6 +11,7 @@ namespace FishNet.Serializing.Helping
         /// Compare if T is default.
         /// </summary>
         public static Func<T, bool> IsDefault { get; set; }
+
         /// <summary>
         /// Compare if T is the same as T2.
         /// </summary>
@@ -48,8 +50,11 @@ namespace FishNet.Serializing.Helping
             if (!a.IsValid() || !b.IsValid())
                 return false;
 
-            if (a.handle != 0 || b.handle != 0)
-                return a.handle == b.handle;
+            ulong aHandle = UnityCompatibility.GetSceneHandleRaw(a);
+            ulong bHandle = UnityCompatibility.GetSceneHandleRaw(b);
+
+            if (aHandle != 0 || bHandle != 0)
+                return aHandle == bHandle;
 
             return a.name == b.name;
         }

--- a/Assets/FishNet/Runtime/Serializing/SceneComparer.cs
+++ b/Assets/FishNet/Runtime/Serializing/SceneComparer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using FishNet.Utility;
+using System.Collections.Generic;
 using UnityEngine.SceneManagement;
 
 namespace FishNet.Serializing.Helping
@@ -7,12 +8,12 @@ namespace FishNet.Serializing.Helping
     {
         public override bool Equals(Scene a, Scene b)
         {
-            return a.handle == b.handle;
+            return UnityCompatibility.GetSceneHandleRaw(a) == UnityCompatibility.GetSceneHandleRaw(b);
         }
 
         public override int GetHashCode(Scene obj)
         {
-            return obj.handle;
+            return UnityCompatibility.GetSceneHandleRaw(obj).GetHashCode();
         }
     }
 }

--- a/Assets/FishNet/Runtime/UnityCompatibility.cs
+++ b/Assets/FishNet/Runtime/UnityCompatibility.cs
@@ -1,0 +1,54 @@
+using UnityEngine.SceneManagement;
+
+namespace FishNet.Utility
+{
+    /// <summary>
+    /// Compatibility helpers for Unity API changes across supported Unity versions.
+    /// </summary>
+    public static class UnityCompatibility
+    {
+        /// <summary>
+        /// Returns a runtime object identifier using Unity's current object identity API.
+        /// </summary>
+        public static ulong GetObjectRuntimeId(UnityEngine.Object obj)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return obj.GetEntityId().GetRawData();
+#else
+            return unchecked((uint)obj.GetInstanceID());
+#endif
+        }
+
+        /// <summary>
+        /// Returns a raw scene handle value using Unity's current SceneHandle API.
+        /// </summary>
+        public static ulong GetSceneHandleRaw(Scene scene)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return scene.handle.GetRawData();
+#else
+            return unchecked((uint)(int)scene.handle);
+#endif
+        }
+
+        /// <summary>
+        /// Creates a SceneHandle from raw scene handle data.
+        /// </summary>
+        public static SceneHandle SceneHandleFromRaw(ulong rawHandle)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return SceneHandle.FromRawData(rawHandle);
+#else
+            return (SceneHandle)(int)rawHandle;
+#endif
+        }
+
+        /// <summary>
+        /// Returns true if the scene has a non-zero raw handle.
+        /// </summary>
+        public static bool HasValidSceneHandle(Scene scene)
+        {
+            return scene.IsValid() && GetSceneHandleRaw(scene) != 0;
+        }
+    }
+}

--- a/Assets/FishNet/Runtime/UnityCompatibility.cs.meta
+++ b/Assets/FishNet/Runtime/UnityCompatibility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c3a88ed478506c145a5efcd3e7c04fd6


### PR DESCRIPTION
## Summary

This PR fixes Unity 6.5 compilation errors caused by obsolete Unity APIs that are now treated as compile-breaking errors.

Unity 6.5 reports direct `Object.GetInstanceID()` usage as obsolete and recommends `GetEntityId()`, and deprecates implicit `SceneHandle` conversions to/from `int` in favor of `GetRawData()` and `FromRawData()`.

## Changes

* Added `UnityCompatibility` helper methods for Unity-version-safe access to:
  * `UnityEngine.Object` runtime IDs
  * raw `SceneHandle` values
  * `SceneHandle` construction from raw data
* Replaced obsolete `SceneHandle` implicit `int` conversions with raw handle access.
* Updated scene lookup/comparison code to use raw scene handles.
* Updated unloaded scene tracking to avoid obsolete handle conversions.
* Removed reliance on `GetInstanceID() < 0` for observer condition cleanup and replaced it with explicit runtime-instance tracking.

## Validation

Tested in Unity `6000.5.0f1`.

Validation performed:

* Project compiles with zero errors.
* Host/client connection succeeds using Tugboat.
* Client disconnect/reconnect succeeds.
* Global network scene loading works.
* Global network scene unloading works while clients are connected.
* Late-joining client correctly receives currently loaded global network scene.