### PR TITLE
fix: Unity 6.5 Scene.handle migration (int to ulong) with old version

### DIFF
--- a/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/SceneLoadData.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/SceneLoadData.cs
@@ -1,7 +1,7 @@
-﻿using FishNet.Object;
-using FishNet.Serializing.Helping;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using FishNet.Object;
+using FishNet.Serializing.Helping;
 using UnityEngine.SceneManagement;
 
 namespace FishNet.Managing.Scened
@@ -50,13 +50,13 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandle">Scene to load by handle.</param>
-        public SceneLoadData(int sceneHandle) : this(new int[] { sceneHandle }, null) { }
+        public SceneLoadData(ulong sceneHandle) : this(new[] { sceneHandle }, null) { }
 
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandle">Scene to load by handle.</param>
         /// <param name = "sceneName">Scene to load by name.</param>
-        public SceneLoadData(int sceneHandle, string sceneName) : this(new SceneLookupData(sceneHandle, sceneName)) { }
+        public SceneLoadData(ulong sceneHandle, string sceneName) : this(new SceneLookupData(sceneHandle, sceneName)) { }
 
         /// <summary>
         /// </summary>
@@ -76,7 +76,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandles">Scenes to load by handle.</param>
-        public SceneLoadData(List<int> sceneHandles) : this(sceneHandles.ToArray(), null) { }
+        public SceneLoadData(List<ulong> sceneHandles) : this(sceneHandles.ToArray(), null) { }
 
         /// <summary>
         /// </summary>
@@ -91,7 +91,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandles">Scenes to load by handle.</param>
-        public SceneLoadData(int[] sceneHandles) : this(sceneHandles, null) { }
+        public SceneLoadData(ulong[] sceneHandles) : this(sceneHandles, null) { }
 
         /// <summary>
         /// </summary>
@@ -132,7 +132,7 @@ namespace FishNet.Managing.Scened
         /// </summary>
         /// <param name = "sceneHandles">Scenes to load by handle.</param>
         /// <param name = "movedNetworkObjects">NetworkObjects to move to the first specified scene.</param>
-        public SceneLoadData(int[] sceneHandles, NetworkObject[] movedNetworkObjects)
+        public SceneLoadData(ulong[] sceneHandles, NetworkObject[] movedNetworkObjects)
         {
             SceneLookupData[] datas = SceneLookupData.CreateData(sceneHandles);
             Construct(datas, movedNetworkObjects);

--- a/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/SceneUnloadData.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/LoadUnloadDatas/SceneUnloadData.cs
@@ -42,7 +42,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandle">Scene to unload by handle.</param>
-        public SceneUnloadData(int sceneHandle) : this(new int[] { sceneHandle }) { }
+        public SceneUnloadData(ulong sceneHandle) : this(new[] { sceneHandle }) { }
 
         /// <summary>
         /// </summary>
@@ -65,7 +65,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandles">Scenes to unload by handles.</param>
-        public SceneUnloadData(List<int> sceneHandles) : this(sceneHandles.ToArray()) { }
+        public SceneUnloadData(List<ulong> sceneHandles) : this(sceneHandles.ToArray()) { }
 
         /// <summary>
         /// </summary>
@@ -86,7 +86,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "sceneHandles">Scenes to unload by handles.</param>
-        public SceneUnloadData(int[] sceneHandles)
+        public SceneUnloadData(ulong[] sceneHandles)
         {
             SceneLookupDatas = SceneLookupData.CreateData(sceneHandles);
         }

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneHandleExtensions.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneHandleExtensions.cs
@@ -1,0 +1,23 @@
+using UnityEngine.SceneManagement;
+
+namespace FishNet.Managing.Scened
+{
+    internal static class SceneHandleExtensions
+    {
+        /// <summary>
+        /// Returns the raw handle identifier of a scene as a ulong.
+        /// </summary>
+        /// <remarks>
+        /// Unity 6000.5+ changed Scene.handle to an EntityId struct exposing GetRawData().
+        /// Earlier versions expose handle as an int.
+        /// </remarks>
+        public static ulong GetHandleId(this Scene s)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return s.handle.GetRawData();
+#else
+            return (ulong)(uint)s.handle;
+#endif
+        }
+    }
+}

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneLookupData.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneLookupData.cs
@@ -1,6 +1,6 @@
-﻿using GameKit.Dependencies.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using GameKit.Dependencies.Utilities;
 using UnityEngine.SceneManagement;
 
 namespace FishNet.Managing.Scened
@@ -24,7 +24,7 @@ namespace FishNet.Managing.Scened
             return names;
         }
 
-        
+
         /// <summary>
         /// Returns Names from SceneLookupData.
         /// </summary>
@@ -48,7 +48,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// Handle of the scene. If value is 0, then handle is not used.
         /// </summary>
-        public int Handle;
+        public ulong Handle;
         /// <summary>
         /// Name of the scene.
         /// </summary>
@@ -62,7 +62,7 @@ namespace FishNet.Managing.Scened
             {
                 if (string.IsNullOrEmpty(Name))
                     return string.Empty;
-                
+
                 string name = System.IO.Path.GetFileName(Name);
                 return RemoveUnityExtension(name);
             }
@@ -89,7 +89,7 @@ namespace FishNet.Managing.Scened
         /// <param name = "scene">Scene to generate from.</param>
         public SceneLookupData(Scene scene)
         {
-            Handle = scene.handle;
+            Handle = scene.handle.GetRawData();
             Name = scene.name;
         }
 
@@ -104,7 +104,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// </summary>
         /// <param name = "handle">Scene handle to generate from.</param>
-        public SceneLookupData(int handle)
+        public SceneLookupData(ulong handle)
         {
             Handle = handle;
         }
@@ -113,7 +113,7 @@ namespace FishNet.Managing.Scened
         /// </summary>
         /// <param name = "handle">Scene handle to generate from.</param>
         /// <param name = "name">Name to generate from if handle is 0.</param>
-        public SceneLookupData(int handle, string name)
+        public SceneLookupData(ulong handle, string name)
         {
             Handle = handle;
             Name = name;
@@ -212,7 +212,7 @@ namespace FishNet.Managing.Scened
         /// </summary>
         /// <param name = "scene">Scene handle to create from.</param>
         /// <returns></returns>
-        public static SceneLookupData CreateData(int handle) => new(handle);
+        public static SceneLookupData CreateData(ulong handle) => new(handle);
 
         /// <summary>
         /// Returns a SceneLookupData collection.
@@ -233,7 +233,7 @@ namespace FishNet.Managing.Scened
         /// </summary>
         /// <param name = "handles">Scene handles to create from.</param>
         /// <returns></returns>
-        public static SceneLookupData[] CreateData(List<int> handles) => CreateData(handles.ToArray());
+        public static SceneLookupData[] CreateData(List<ulong> handles) => CreateData(handles.ToArray());
 
         /// <summary>
         /// Returns a SceneLookupData collection.
@@ -345,11 +345,11 @@ namespace FishNet.Managing.Scened
         /// </summary>
         /// <param name = "handles">Scene handles to create from.</param>
         /// <returns></returns>
-        public static SceneLookupData[] CreateData(int[] handles)
+        public static SceneLookupData[] CreateData(ulong[] handles)
         {
             bool invalidFound = false;
             List<SceneLookupData> result = new();
-            foreach (int item in handles)
+            foreach (var item in handles)
             {
                 if (item == 0)
                 {
@@ -402,7 +402,7 @@ namespace FishNet.Managing.Scened
             if (Handle != 0)
             {
                 result = SceneManager.GetScene(Handle);
-                if (result.handle != 0)
+                if (result.handle.GetRawData() != 0)
                     foundByHandle = true;
             }
 

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneLookupData.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneLookupData.cs
@@ -89,7 +89,7 @@ namespace FishNet.Managing.Scened
         /// <param name = "scene">Scene to generate from.</param>
         public SceneLookupData(Scene scene)
         {
-            Handle = scene.handle.GetRawData();
+            Handle = scene.GetHandleId();
             Name = scene.name;
         }
 
@@ -402,7 +402,7 @@ namespace FishNet.Managing.Scened
             if (Handle != 0)
             {
                 result = SceneManager.GetScene(Handle);
-                if (result.handle.GetRawData() != 0)
+                if (result.GetHandleId() != 0)
                     foundByHandle = true;
             }
 

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -1,4 +1,8 @@
-﻿using FishNet.Connection;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using FishNet.Connection;
 using FishNet.Managing.Client;
 using FishNet.Managing.Logging;
 using FishNet.Managing.Server;
@@ -7,10 +11,6 @@ using FishNet.Serializing.Helping;
 using FishNet.Transporting;
 using GameKit.Dependencies.Utilities;
 using GameKit.Dependencies.Utilities.Types;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
@@ -34,11 +34,11 @@ namespace FishNet.Managing.Scened
             /// <summary>
             /// Scene handles which have clients that have not yet confirmed the loading status.
             /// </summary>
-            private Dictionary<int, HashSet<NetworkConnection>> _scenesWithPendingLoads = new();
+            private Dictionary<ulong, HashSet<NetworkConnection>> _scenesWithPendingLoads = new();
             /// <summary>
             /// Clients with pending loads, and each scene handle pending.
             /// </summary>
-            private Dictionary<NetworkConnection, List<int>> _clientsWithPendingLoads = new();
+            private Dictionary<NetworkConnection, List<ulong>> _clientsWithPendingLoads = new();
             /// <summary>
             /// Clients which have been sent the initial scene load with no scenes specified.
             /// </summary>
@@ -49,11 +49,11 @@ namespace FishNet.Managing.Scened
             /// <summary>
             /// Adds a pending load for a client.
             /// </summary>
-            public void AddClientToScene(NetworkConnection connection, int sceneHandle)
+            public void AddClientToScene(NetworkConnection connection, ulong sceneHandle)
             {
                 /* The client has 1 or more pending loads already. See
                  * if the specified scene is already pending. */
-                if (_clientsWithPendingLoads.TryGetValueIL2CPP(connection, out List<int> sceneList))
+                if (_clientsWithPendingLoads.TryGetValueIL2CPP(connection, out List<ulong> sceneList))
                 {
                     //Scene is already marked for the connection.
                     if (sceneList.Contains(sceneHandle))
@@ -81,14 +81,14 @@ namespace FishNet.Managing.Scened
             /// Removes a client from all pending loads.
             /// </summary
             /// <returns>Scene handles which no longer have clients pending loads.</returns>
-            internal List<int> RemoveClientFromAllScenes(NetworkConnection conn)
+            internal List<ulong> RemoveClientFromAllScenes(NetworkConnection conn)
             {
-                List<int> emptyScenes = new();
+                List<ulong> emptyScenes = new();
 
-                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<int> sceneList))
+                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<ulong> sceneList))
                     return emptyScenes;
 
-                foreach (int sceneHandle in sceneList)
+                foreach (var sceneHandle in sceneList)
                 {
                     /* If the scene is in the clients list then it should
                      * be in scenesWithPendingLoads. This is a safety check but
@@ -113,7 +113,7 @@ namespace FishNet.Managing.Scened
             /// </summary
             /// <param name="sceneHasNoPendingLoads">Becomes true if the scene which the connection is being removed from has no more pending loads.</param>
             /// <returns>True if the client had the specified scene as pending.</returns>
-            internal bool RemoveClientFromScene(NetworkConnection conn, int sceneHandle, out bool sceneHasNoPendingLoads)
+            internal bool RemoveClientFromScene(NetworkConnection conn, ulong sceneHandle, out bool sceneHasNoPendingLoads)
             {
                 // The scene has does not have any pending clients.
                 if (!_scenesWithPendingLoads.TryGetValueIL2CPP(sceneHandle, out HashSet<NetworkConnection> connectionsLoadingScene))
@@ -136,7 +136,7 @@ namespace FishNet.Managing.Scened
                 /* If client does not have any pending loads then
                  * there is nothing to remove, which means the requested
                  * scene still has clients in it. */
-                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<int> sceneList))
+                if (!_clientsWithPendingLoads.TryGetValueIL2CPP(conn, out List<ulong> sceneList))
                 {
                     sceneHasNoPendingLoads = false;
                     return false;
@@ -176,7 +176,7 @@ namespace FishNet.Managing.Scened
             /// <summary>
             /// Returns if a scene has any number of clients still pending load.
             /// </summary>
-            internal bool HasSceneAnyPendingLoads(int sceneHandle) => _scenesWithPendingLoads.TryGetValueIL2CPP(sceneHandle, out _);
+            internal bool HasSceneAnyPendingLoads(ulong sceneHandle) => _scenesWithPendingLoads.TryGetValueIL2CPP(sceneHandle, out _);
 
             /// <summary>
             /// Clears all information.
@@ -635,7 +635,7 @@ namespace FishNet.Managing.Scened
                 /* True if SceneConnections has no more connections
                  * in its scene, as well if the scene checked is in
                  * has no other clients pending load confirmation. */
-                bool isSceneNowEmpty = removed && hs.Count == 0 && !_pendingClientSceneLoads.HasSceneAnyPendingLoads(scene.handle);
+                bool isSceneNowEmpty = removed && hs.Count == 0 && !_pendingClientSceneLoads.HasSceneAnyPendingLoads(scene.handle.GetRawData());
 
                 //True if not a global scene and not in scenes to be manually unloaded.
                 bool notGlobalAndNotManualUnload = !IsGlobalScene(scene) && !_manualUnloadScenes.Contains(scene);
@@ -1058,7 +1058,7 @@ namespace FishNet.Managing.Scened
                 /* Scene queue data scenes.
                  * All scenes in the scene queue data whether they will be loaded or not. */
                 List<string> requestedLoadSceneNames = new();
-                List<int> requestedLoadSceneHandles = new();
+                List<ulong> requestedLoadSceneHandles = new();
 
                 /* Make a null filled array. This will be populated
                  * using loaded scenes, or already loaded (eg cannot be loaded) scenes. */
@@ -1081,7 +1081,7 @@ namespace FishNet.Managing.Scened
                     {
                         requestedLoadSceneNames.Add(s.name);
                         if (byHandle)
-                            requestedLoadSceneHandles.Add(s.handle);
+                            requestedLoadSceneHandles.Add(s.handle.GetRawData());
                     }
 
                     if (CanLoadScene(data, lookupData))
@@ -1124,7 +1124,7 @@ namespace FishNet.Managing.Scened
                 }
 
                 // Connection scenes handles prior to ConnectionScenes being modified.
-                List<int> connectionScenesHandlesCached = new();
+                List<ulong> connectionScenesHandlesCached = new();
                 // If replacing scenes.
                 if (replaceScenes != ReplaceOption.None)
                 {
@@ -1137,7 +1137,7 @@ namespace FishNet.Managing.Scened
                     {
                         Scene[] sceneConnectionsKeys = SceneConnections.Keys.ToArray();
                         for (int i = 0; i < sceneConnectionsKeys.Length; i++)
-                            connectionScenesHandlesCached.Add(sceneConnectionsKeys[i].handle);
+                            connectionScenesHandlesCached.Add(sceneConnectionsKeys[i].handle.GetRawData());
 
                         // If global then remove all connections from all scenes.
                         if (data.ScopeType == SceneScopeType.Global)
@@ -1155,7 +1155,7 @@ namespace FishNet.Managing.Scened
                     else
                     {
                         foreach (Scene s in NetworkManager.ClientManager.Connection.Scenes)
-                            connectionScenesHandlesCached.Add(s.handle);
+                            connectionScenesHandlesCached.Add(s.handle.GetRawData());
                     }
                 }
 
@@ -1181,7 +1181,7 @@ namespace FishNet.Managing.Scened
                         if (requestedLoadSceneNames.Contains(s.name))
                             continue;
                         // Same as above but using handles.
-                        if (requestedLoadSceneHandles.Contains(s.handle))
+                        if (requestedLoadSceneHandles.Contains(s.handle.GetRawData()))
                             continue;
                         /* Cannot unload global scenes. If
                          * replace scenes was used for a global
@@ -1193,7 +1193,7 @@ namespace FishNet.Managing.Scened
                         if (_manualUnloadScenes.Contains(s))
                             continue;
 
-                        bool inScenesCache = connectionScenesHandlesCached.Contains(s.handle);
+                        bool inScenesCache = connectionScenesHandlesCached.Contains(s.handle.GetRawData());
                         HashSet<NetworkConnection> conns;
                         bool inScenesCurrent = SceneConnections.ContainsKey(s);
                         // If was in scenes previously but isnt now then no connections reside in the scene.
@@ -2245,13 +2245,13 @@ namespace FishNet.Managing.Scened
         /// </summary>
         /// <param name = "sceneHandle"></param>
         /// <returns></returns>
-        public static Scene GetScene(int sceneHandle)
+        public static Scene GetScene(ulong sceneHandle)
         {
             int count = UnitySceneManager.sceneCount;
             for (int i = 0; i < count; i++)
             {
                 Scene s = UnitySceneManager.GetSceneAt(i);
-                if (s.handle == sceneHandle)
+                if (s.handle.GetRawData() == sceneHandle)
                     return s;
             }
 
@@ -2354,7 +2354,7 @@ namespace FishNet.Managing.Scened
             {
                 Scene s = scenes[i];
 
-                if (SceneConnections.TryGetValueIL2CPP(s, out _) || _pendingClientSceneLoads.HasSceneAnyPendingLoads(s.handle))
+                if (SceneConnections.TryGetValueIL2CPP(s, out _) || _pendingClientSceneLoads.HasSceneAnyPendingLoads(s.handle.GetRawData()))
                 {
                     scenes.RemoveAt(i);
                     i--;
@@ -2365,7 +2365,7 @@ namespace FishNet.Managing.Scened
         /// <summary>
         /// Adds a pending load for a connection.
         /// </summary>
-        private void AddPendingLoad(NetworkConnection[] conns, int sceneHandle)
+        private void AddPendingLoad(NetworkConnection[] conns, ulong sceneHandle)
         {
             foreach (NetworkConnection c in conns)
             {

--- a/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -635,7 +635,7 @@ namespace FishNet.Managing.Scened
                 /* True if SceneConnections has no more connections
                  * in its scene, as well if the scene checked is in
                  * has no other clients pending load confirmation. */
-                bool isSceneNowEmpty = removed && hs.Count == 0 && !_pendingClientSceneLoads.HasSceneAnyPendingLoads(scene.handle.GetRawData());
+                bool isSceneNowEmpty = removed && hs.Count == 0 && !_pendingClientSceneLoads.HasSceneAnyPendingLoads(scene.GetHandleId());
 
                 //True if not a global scene and not in scenes to be manually unloaded.
                 bool notGlobalAndNotManualUnload = !IsGlobalScene(scene) && !_manualUnloadScenes.Contains(scene);
@@ -1081,7 +1081,7 @@ namespace FishNet.Managing.Scened
                     {
                         requestedLoadSceneNames.Add(s.name);
                         if (byHandle)
-                            requestedLoadSceneHandles.Add(s.handle.GetRawData());
+                            requestedLoadSceneHandles.Add(s.GetHandleId());
                     }
 
                     if (CanLoadScene(data, lookupData))
@@ -1137,7 +1137,7 @@ namespace FishNet.Managing.Scened
                     {
                         Scene[] sceneConnectionsKeys = SceneConnections.Keys.ToArray();
                         for (int i = 0; i < sceneConnectionsKeys.Length; i++)
-                            connectionScenesHandlesCached.Add(sceneConnectionsKeys[i].handle.GetRawData());
+                            connectionScenesHandlesCached.Add(sceneConnectionsKeys[i].GetHandleId());
 
                         // If global then remove all connections from all scenes.
                         if (data.ScopeType == SceneScopeType.Global)
@@ -1155,7 +1155,7 @@ namespace FishNet.Managing.Scened
                     else
                     {
                         foreach (Scene s in NetworkManager.ClientManager.Connection.Scenes)
-                            connectionScenesHandlesCached.Add(s.handle.GetRawData());
+                            connectionScenesHandlesCached.Add(s.GetHandleId());
                     }
                 }
 
@@ -1181,7 +1181,7 @@ namespace FishNet.Managing.Scened
                         if (requestedLoadSceneNames.Contains(s.name))
                             continue;
                         // Same as above but using handles.
-                        if (requestedLoadSceneHandles.Contains(s.handle.GetRawData()))
+                        if (requestedLoadSceneHandles.Contains(s.GetHandleId()))
                             continue;
                         /* Cannot unload global scenes. If
                          * replace scenes was used for a global
@@ -1193,7 +1193,7 @@ namespace FishNet.Managing.Scened
                         if (_manualUnloadScenes.Contains(s))
                             continue;
 
-                        bool inScenesCache = connectionScenesHandlesCached.Contains(s.handle.GetRawData());
+                        bool inScenesCache = connectionScenesHandlesCached.Contains(s.GetHandleId());
                         HashSet<NetworkConnection> conns;
                         bool inScenesCurrent = SceneConnections.ContainsKey(s);
                         // If was in scenes previously but isnt now then no connections reside in the scene.
@@ -2251,7 +2251,7 @@ namespace FishNet.Managing.Scened
             for (int i = 0; i < count; i++)
             {
                 Scene s = UnitySceneManager.GetSceneAt(i);
-                if (s.handle.GetRawData() == sceneHandle)
+                if (s.GetHandleId() == sceneHandle)
                     return s;
             }
 
@@ -2354,7 +2354,7 @@ namespace FishNet.Managing.Scened
             {
                 Scene s = scenes[i];
 
-                if (SceneConnections.TryGetValueIL2CPP(s, out _) || _pendingClientSceneLoads.HasSceneAnyPendingLoads(s.handle.GetRawData()))
+                if (SceneConnections.TryGetValueIL2CPP(s, out _) || _pendingClientSceneLoads.HasSceneAnyPendingLoads(s.GetHandleId()))
                 {
                     scenes.RemoveAt(i);
                     i--;

--- a/Assets/FishNet/Runtime/Managing/Scened/UnloadedScene.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/UnloadedScene.cs
@@ -10,7 +10,7 @@ namespace FishNet.Managing.Scened
         public UnloadedScene(Scene s)
         {
             Name = s.name;
-            Handle = s.handle.GetRawData();
+            Handle = s.GetHandleId();
         }
 
         public UnloadedScene(string name, ulong handle)
@@ -30,7 +30,7 @@ namespace FishNet.Managing.Scened
             for (int i = 0; i < loadedScenes; i++)
             {
                 Scene s = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
-                if (s.IsValid() && s.handle.GetRawData() == Handle)
+                if (s.IsValid() && s.GetHandleId() == Handle)
                     return s;
             }
 

--- a/Assets/FishNet/Runtime/Managing/Scened/UnloadedScene.cs
+++ b/Assets/FishNet/Runtime/Managing/Scened/UnloadedScene.cs
@@ -5,15 +5,15 @@ namespace FishNet.Managing.Scened
     public struct UnloadedScene
     {
         public readonly string Name;
-        public readonly int Handle;
+        public readonly ulong Handle;
 
         public UnloadedScene(Scene s)
         {
             Name = s.name;
-            Handle = s.handle;
+            Handle = s.handle.GetRawData();
         }
 
-        public UnloadedScene(string name, int handle)
+        public UnloadedScene(string name, ulong handle)
         {
             Name = name;
             Handle = handle;
@@ -30,7 +30,7 @@ namespace FishNet.Managing.Scened
             for (int i = 0; i < loadedScenes; i++)
             {
                 Scene s = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
-                if (s.IsValid() && s.handle == Handle)
+                if (s.IsValid() && s.handle.GetRawData() == Handle)
                     return s;
             }
 

--- a/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -155,11 +155,18 @@ namespace FishNet.Observing
                 foreach (ObserverCondition item in _observerConditions)
                 {
                     item.Deinitialize(destroyed);
-                    /* Use GetInstanceId to ensure the object is actually
-                     * instantiated. If Id is negative, then it's instantiated
-                     * and not a reference to the original object. */
+                    /* Conditions are always Instantiate() clones at this point
+                     * (see Initialize), so destroying any valid entry only ever
+                     * destroys the clone, never the source asset.
+                     * On 6000.5+ use the EntityId API: GetInstanceID()/`< 0`
+                     * route through the obsolete EntityId<->int conversion (CS0618). */
+#if UNITY_6000_5_OR_NEWER
+                    if (destroyed && item.GetEntityId().IsValid())
+                        Destroy(item);
+#else
                     if (destroyed && item.GetInstanceID() < 0)
                         Destroy(item);
+#endif
                 }
 
                 // Clean up lists.

--- a/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -158,7 +158,7 @@ namespace FishNet.Observing
                     /* Use GetInstanceId to ensure the object is actually
                      * instantiated. If Id is negative, then it's instantiated
                      * and not a reference to the original object. */
-                    if (destroyed && item.GetEntityId().IsValid())
+                    if (destroyed && item.GetInstanceID() < 0)
                         Destroy(item);
                 }
 

--- a/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -1,11 +1,11 @@
-﻿using FishNet.Connection;
+﻿using System.Collections.Generic;
+using FishNet.Connection;
 using FishNet.Documenting;
+using FishNet.Managing;
 using FishNet.Managing.Server;
 using FishNet.Object;
 using FishNet.Transporting;
 using GameKit.Dependencies.Utilities;
-using System.Collections.Generic;
-using FishNet.Managing;
 using UnityEngine;
 
 namespace FishNet.Observing
@@ -158,7 +158,7 @@ namespace FishNet.Observing
                     /* Use GetInstanceId to ensure the object is actually
                      * instantiated. If Id is negative, then it's instantiated
                      * and not a reference to the original object. */
-                    if (destroyed && item.GetInstanceID() < 0)
+                    if (destroyed && item.GetEntityId().IsValid())
                         Destroy(item);
                 }
 
@@ -309,10 +309,10 @@ namespace FishNet.Observing
             if (!_initialized)
             {
                 string goName = gameObject == null ? "Empty" : gameObject.name;
-                
+
                 NetworkManager nm = _networkObject == null ? null : _networkObject.NetworkManager;
                 nm.LogError($"{GetType().Name} is not initialized on NetworkObject [{goName}]. RebuildObservers should not be called. If you are able to reproduce this error consistently please report this issue.");
-                
+
                 return ObserverStateChange.Unchanged;
             }
 

--- a/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/Dictionaries.cs
+++ b/Assets/FishNet/Runtime/Plugins/GameKit/Dependencies/Utilities/Dictionaries.cs
@@ -11,7 +11,7 @@ namespace GameKit.Dependencies.Utilities
         /// </summary>
         public static bool TryGetValueIL2CPP<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key, out TValue value)
         {
-            #if ENABLE_IL2CPP && UNITY_IOS || UNITY_ANDROID
+#if ENABLE_IL2CPP && UNITY_IOS || UNITY_ANDROID
             if (dict.ContainsKey(key))
             {
                 value = dict[key];
@@ -20,12 +20,12 @@ namespace GameKit.Dependencies.Utilities
 
                 value = default;
                 return false;
-            #else
+#else
             return dict.TryGetValue(key, out value);
-            #endif
+#endif
         }
 
-     
+
         /// <summary>
         /// Returns values as a list.
         /// </summary>

--- a/Assets/FishNet/Runtime/Serializing/Helping/Comparers.cs
+++ b/Assets/FishNet/Runtime/Serializing/Helping/Comparers.cs
@@ -48,7 +48,7 @@ namespace FishNet.Serializing.Helping
             if (!a.IsValid() || !b.IsValid())
                 return false;
 
-            if (a.handle != 0 || b.handle != 0)
+            if (a.handle.GetRawData() != 0 || b.handle.GetRawData() != 0)
                 return a.handle == b.handle;
 
             return a.name == b.name;

--- a/Assets/FishNet/Runtime/Serializing/Helping/Comparers.cs
+++ b/Assets/FishNet/Runtime/Serializing/Helping/Comparers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using FishNet.Managing.Scened;
 using UnityEngine.SceneManagement;
 
 namespace FishNet.Serializing.Helping
@@ -48,7 +49,7 @@ namespace FishNet.Serializing.Helping
             if (!a.IsValid() || !b.IsValid())
                 return false;
 
-            if (a.handle.GetRawData() != 0 || b.handle.GetRawData() != 0)
+            if (a.GetHandleId() != 0 || b.GetHandleId() != 0)
                 return a.handle == b.handle;
 
             return a.name == b.name;

--- a/Assets/FishNet/Runtime/Serializing/SceneComparer.cs
+++ b/Assets/FishNet/Runtime/Serializing/SceneComparer.cs
@@ -12,7 +12,7 @@ namespace FishNet.Serializing.Helping
 
         public override int GetHashCode(Scene obj)
         {
-            return obj.handle;
+            return obj.handle.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
## Abstract

Unity 6000.5 changed `Scene.handle` from an `int` to an `EntityId` struct (raw value exposed via `GetRawData()`), and deprecated the `EntityId` / `int` implicit conversions. This broke FishNet scene loading/unloading, the scene comparers, and an observer-cleanup check. This PR migrates the scened code to the new type while keeping Unity 6.0 (and earlier 6.x) compiling.

Tested without errors on **Unity 6000.5** and **Unity 6000.0**.

## Report

### Scene handle: `int` to `ulong`
- Widened scene-handle storage from `int` to `ulong` across the scened API: `SceneLookupData`, `SceneLoadData`, `SceneUnloadData`, `UnloadedScene`, `SceneManager` pending-load maps, `GetScene(...)`, etc.
- Added a single `Scene.GetHandleId()` extension (`SceneHandleExtensions`) that isolates the only version-specific code:
  - `UNITY_6000_5_OR_NEWER` uses `scene.handle.GetRawData()`
  - older uses `(ulong)(uint)scene.handle`
- All handle-read sites route through this helper, so no `#if` is scattered across the codebase and no public type flips per Unity version.
- `SceneComparer.GetHashCode` now returns `obj.handle.GetHashCode()` (works on both `int` and the `EntityId` struct).

### NetworkObserver condition cleanup
- On `UNITY_6000_5_OR_NEWER`, use `item.GetEntityId().IsValid()` instead of `GetInstanceID() < 0`.
  - `GetInstanceID()`/`< 0` route through the now-obsolete `EntityId` /`int` conversion, and a `ulong`-based `< 0` is always false. so the old sign trick would silently never destroy.
  - Conditions in this list are always `Instantiate()`'d clones (see `Initialize`), so `IsValid()` destroys exactly the clones and never a source asset.
- Older Unity uses `GetInstanceID() < 0`.

### Minor
- Refined `Dictionaries.cs` (`TryGetValueIL2CPP`).

## Conclusion
- Scene handle is only ever used as a dictionary key / equality token, so the exact `int`to`ulong` encoding on older Unity doesn't matter as long as it's consistent.
- Please confirm `UNITY_6000_5_OR_NEWER` is the correct boundary (i.e. `GetRawData()` / the `EntityId` migration did not land before 6000.5).