### PR TITLE
fix(serializing): reuse larger pooled writers

### DIFF
--- a/Assets/FishNet/Runtime/Serializing/WriterPool.cs
+++ b/Assets/FishNet/Runtime/Serializing/WriterPool.cs
@@ -90,6 +90,14 @@ namespace FishNet.Serializing
             // There is already one pooled.
             if (_lengthPool.TryGetValue(index, out stack) && stack.TryPop(out result))
             {
+                if (stack.Count == 0)
+                    _lengthPool.Remove(index);
+
+                result.Clear(networkManager);
+            }
+            // There is a larger writer pooled.
+            else if (TryPopLengthWriterAbove(index, out result))
+            {
                 result.Clear(networkManager);
             }
             // Not pooled yet or failed to pop.
@@ -105,6 +113,46 @@ namespace FishNet.Serializing
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Tries to pop the closest writer from a bucket above minimum index.
+        /// </summary>
+        private static bool TryPopLengthWriterAbove(int minimumIndex, out PooledWriter writer)
+        {
+            int foundIndex = int.MaxValue;
+            Stack<PooledWriter> foundStack = null;
+
+            foreach (KeyValuePair<int, Stack<PooledWriter>> entry in _lengthPool)
+            {
+                if (entry.Key <= minimumIndex)
+                    continue;
+                if (entry.Value.Count == 0)
+                    continue;
+                if (entry.Key < foundIndex)
+                {
+                    foundIndex = entry.Key;
+                    foundStack = entry.Value;
+                }
+            }
+
+            if (foundStack == null)
+            {
+                writer = null;
+                return false;
+            }
+
+            bool popped = foundStack.TryPop(out writer);
+            if (!popped)
+            {
+                writer = null;
+                return false;
+            }
+
+            if (foundStack.Count == 0)
+                _lengthPool.Remove(foundIndex);
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- keep the existing exact length-bucket lookup fast path
- reuse the nearest larger length-pool bucket before growing another writer
- remove empty length buckets after popping writers

## Why
On long-running servers with variable payload sizes, length-pooled writers can be stored under a larger capacity bucket than the later requested length bucket. Because `Retrieve(length)` only checked the exact bucket, those larger pooled writers could remain rooted by the static `WriterPool._lengthPool` and not be reused.

In a Minecraft-like server with large world streaming and frequent player reconnects, this caused FishNet-side retained allocations after players disconnected and all game resources were cleaned up. After many reconnects, server RAM usage kept growing until OOM. Reusing larger buckets stabilized memory usage.

## Validation
- inspected focused `WriterPool` diff
- ran whitespace check with CRLF-aware Git settings
- attempted solution build, but Unity-generated `.csproj` files are not present in this clone