### PR TITLE
fix(serializing): reuse larger pooled writers

### DIFF
--- a/Assets/FishNet/Runtime/Serializing/WriterPool.cs
+++ b/Assets/FishNet/Runtime/Serializing/WriterPool.cs
@@ -90,6 +90,14 @@ namespace FishNet.Serializing
             // There is already one pooled.
             if (_lengthPool.TryGetValue(index, out stack) && stack.TryPop(out result))
             {
+                if (stack.Count == 0)
+                    _lengthPool.Remove(index);
+
+                result.Clear(networkManager);
+            }
+            // There is a larger writer pooled.
+            else if (TryPopLengthWriterAbove(index, out result))
+            {
                 result.Clear(networkManager);
             }
             // Not pooled yet or failed to pop.
@@ -105,6 +113,46 @@ namespace FishNet.Serializing
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Tries to pop the closest writer from a bucket above minimum index.
+        /// </summary>
+        private static bool TryPopLengthWriterAbove(int minimumIndex, out PooledWriter writer)
+        {
+            int foundIndex = int.MaxValue;
+            Stack<PooledWriter> foundStack = null;
+
+            foreach (KeyValuePair<int, Stack<PooledWriter>> entry in _lengthPool)
+            {
+                if (entry.Key <= minimumIndex)
+                    continue;
+                if (entry.Value.Count == 0)
+                    continue;
+                if (entry.Key < foundIndex)
+                {
+                    foundIndex = entry.Key;
+                    foundStack = entry.Value;
+                }
+            }
+
+            if (foundStack == null)
+            {
+                writer = null;
+                return false;
+            }
+
+            bool popped = foundStack.TryPop(out writer);
+            if (!popped)
+            {
+                writer = null;
+                return false;
+            }
+
+            if (foundStack.Count == 0)
+                _lengthPool.Remove(foundIndex);
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
This changes `WriterPool.Retrieve(length)` so it can reuse a writer from the closest larger length bucket when the exact bucket is empty.

The exact-bucket path stays the same. The fallback only runs when there is no writer available for the requested bucket, and empty buckets are removed after popping.

## Background
I ran into this on a long-running Minecraft-like server with chunk streaming and large, variable payload sizes. Each player reconnect caused FishNet to retain some memory even after all player-owned resources were cleaned up. After enough reconnects, memory usage kept climbing until the server eventually ran out of RAM.

The issue is that a writer can be returned to the length pool under a bucket based on its actual capacity, which may be larger than the bucket requested later. Since `Retrieve(length)` only checked the exact bucket, larger cached writers could sit in `_lengthPool` and remain strongly referenced instead of being reused.

Reusing the nearest larger bucket fixed the retained allocation growth in that workload and kept memory usage stable across repeated reconnects.