### PR TITLE
fix: NetworkAnimator delay/desync on host's own character observed by clients

### DIFF
--- a/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/FishNet/Runtime/Generated/Component/NetworkAnimator/NetworkAnimator.cs
@@ -597,10 +597,16 @@ namespace FishNet.Component.Animating
                 if (TimeManager.LocalTick < _startTick)
                     return;
 
-                ReceivedServerData rd = _fromServerBuffer.Dequeue();
-                ArraySegment<byte> segment = rd.GetArraySegment();
-                ApplyParametersUpdated(ref segment);
-                rd.Dispose();
+                //Apply the entire backlog instead of one entry per tick, so a burst
+                //of updates (e.g. from a caught-up frame) doesn't leave the client
+                //visibly behind for multiple ticks.
+                while (_fromServerBuffer.Count > 0)
+                {
+                    ReceivedServerData rd = _fromServerBuffer.Dequeue();
+                    ArraySegment<byte> segment = rd.GetArraySegment();
+                    ApplyParametersUpdated(ref segment);
+                    rd.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

Clients observing the host's own character saw its animation lag noticeably behind its position, host moves, animation catches up later. Only affected the host, client-to-client stayed in sync.

## Fix

_fromServerBuffer drains one entry per tick in TimeManager_OnPreTick. The host's own data bypasses the ClientAuthoritativeUpdate buffer cap and sends on every OnPostTick, so a burst can enqueue faster than the fixed drain rate and the client falls behind. Changed it to drain the full backlog per tick instead of one entry. AnimatorUpdated diffs against last-sent values so applying several entries back-to-back loses nothing, including triggers and layer states.

https://github.com/user-attachments/assets/658e5ba2-c1f7-4408-b6f7-471543fd07ef

